### PR TITLE
Add auth blueprint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,8 @@ secret*
 *credential*
 .snowflake-creds
 *auth*
+!dataqe_app/auth/
+!dataqe_app/auth/**
 *password*
 *token*
 *.pem

--- a/dataqe_app/auth/routes.py
+++ b/dataqe_app/auth/routes.py
@@ -1,0 +1,38 @@
+from flask import Blueprint, render_template, request, redirect, url_for, flash
+from flask_login import login_user, logout_user, login_required, current_user
+
+from dataqe_app import db, login_manager
+from dataqe_app.models import User
+
+
+auth_bp = Blueprint('auth', __name__)
+
+
+@login_manager.user_loader
+def load_user(user_id):
+    return User.query.get(int(user_id))
+
+
+@auth_bp.route('/login', methods=['GET', 'POST'])
+def login():
+    if current_user.is_authenticated:
+        return redirect(url_for('executions.results_dashboard'))
+
+    if request.method == 'POST':
+        username = request.form.get('username')
+        password = request.form.get('password')
+        user = User.query.filter_by(username=username).first()
+        if user and user.check_password(password):
+            login_user(user)
+            return redirect(url_for('executions.results_dashboard'))
+        flash('Invalid username or password', 'error')
+
+    return render_template('login.html')
+
+
+@auth_bp.route('/logout')
+@login_required
+def logout():
+    logout_user()
+    flash('Logged out successfully.', 'success')
+    return redirect(url_for('auth.login'))

--- a/tests/test_data_diffs.py
+++ b/tests/test_data_diffs.py
@@ -1,0 +1,21 @@
+import os
+import sys
+import numpy as np
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from core.data_diffs import normalize_key_value, compare_values
+
+
+def test_normalize_key_value():
+    assert normalize_key_value(' Test_Value ') == 'testvalue'
+    assert normalize_key_value(np.nan) == 'NA'
+    assert normalize_key_value(None) == 'NA'
+
+
+def test_compare_values():
+    assert compare_values(np.nan, np.nan) is True
+    assert compare_values(np.nan, 1) is False
+    assert compare_values(5, 5) is True
+    assert compare_values('Hello', 'hello') is True
+    assert compare_values('Hello', 'world') is False
+    assert compare_values(True, True) is True

--- a/tests/test_data_processing.py
+++ b/tests/test_data_processing.py
@@ -1,0 +1,66 @@
+import os
+import sys
+import pandas as pd
+from pandas.testing import assert_frame_equal
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from core.data_processing import (
+    convert_bytearray_columns,
+    remove_timezone_info,
+    fill_nulls_and_blanks,
+    strip_string_values,
+    standardize_column_names,
+)
+
+
+def test_convert_bytearray_columns():
+    df = pd.DataFrame({
+        'A': [bytearray(b'abc'), bytearray(b'def'), 'ghi'],
+        'B': [1, 2, 3],
+    })
+    result = convert_bytearray_columns(df.copy())
+    expected = pd.DataFrame({'A': ['abc', 'def', 'ghi'], 'B': [1, 2, 3]})
+    assert_frame_equal(result, expected)
+
+
+def test_remove_timezone_info():
+    df = pd.DataFrame({
+        'date': [pd.Timestamp('2021-01-01', tz='UTC'), pd.Timestamp('2021-01-02', tz='UTC')],
+        'value': [1, 2],
+    })
+    result = remove_timezone_info(df.copy())
+    expected = pd.DataFrame({
+        'date': [pd.Timestamp('2021-01-01'), pd.Timestamp('2021-01-02')],
+        'value': [1, 2],
+    })
+    assert_frame_equal(result, expected)
+    assert result['date'].dt.tz is None
+
+
+def test_fill_nulls_and_blanks():
+    df = pd.DataFrame({
+        'num': [1, float('nan'), 3],
+        'text': ['a', '', None],
+        'flag': [True, None, False],
+    })
+    result = fill_nulls_and_blanks(df.copy(), fill_value=0)
+    expected = pd.DataFrame({
+        'num': [1.0, 0.0, 3.0],
+        'text': ['a', '0', '0'],
+        'flag': [True, '0', False],
+    })
+    assert_frame_equal(result.reset_index(drop=True), expected)
+
+
+def test_strip_string_values():
+    df = pd.DataFrame({'A': ['  hi ', ' there '], 'B': [1, 2]})
+    result = strip_string_values(df.copy())
+    expected = pd.DataFrame({'A': ['hi', 'there'], 'B': [1, 2]})
+    assert_frame_equal(result, expected)
+
+
+def test_standardize_column_names():
+    df = pd.DataFrame({' col_one ': [1], 'colTwo ': [2], 'COL_THREE': [3]})
+    result = standardize_column_names(df.copy())
+    assert result.columns.tolist() == ['COL ONE', 'COLTWO', 'COL THREE']

--- a/tests/test_file_parsing.py
+++ b/tests/test_file_parsing.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import pandas as pd
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from core.file_parsing import CSVFileParser
+
+
+def test_read_csv(tmp_path):
+    csv_path = tmp_path / "sample.csv"
+    csv_path.write_text("a,b\n1,2\n3,4\n")
+
+    df = CSVFileParser.read_csv(str(csv_path))
+    expected = pd.DataFrame({"a": [1, 3], "b": [2, 4]})
+    pd.testing.assert_frame_equal(df, expected)
+
+
+def test_write_to_csv(tmp_path):
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+    out_path = tmp_path / "out.csv"
+    result = CSVFileParser.write_to_csv(df, str(out_path))
+    assert result is True
+    read_back = pd.read_csv(out_path)
+    pd.testing.assert_frame_equal(read_back, df)
+
+
+def test_preview_csv(tmp_path):
+    csv_path = tmp_path / "sample.csv"
+    csv_path.write_text("a,b\n1,2\n3,4\n5,6\n")
+
+    preview = CSVFileParser.preview_csv(str(csv_path), num_rows=2)
+    expected = pd.DataFrame({"a": [1, 3], "b": [2, 4]})
+    pd.testing.assert_frame_equal(preview, expected)


### PR DESCRIPTION
## Summary
- add minimal auth blueprint providing login/logout
- allow auth folder in `.gitignore`

## Testing
- `pytest -q tests` *(fails: pandas OptionError)*

------
https://chatgpt.com/codex/tasks/task_e_684499871efc8323951a0004b20d374d