### PR TITLE
Fix login link in home page

### DIFF
--- a/dataqe_app/templates/index.html
+++ b/dataqe_app/templates/index.html
@@ -11,7 +11,7 @@
                 A centralized platform for managing and comparing SQL query pairs across teams and projects.
             </p>
             <div class="mt-5">
-                <a href="{{ url_for('login') }}" class="btn btn-primary btn-lg px-5">Get Started</a>
+                <a href="{{ url_for('auth.login') }}" class="btn btn-primary btn-lg px-5">Get Started</a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- update the index template so "Get Started" points to `auth.login`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68449e8e37b483238988dab53726f5ef