### PR TITLE
Add test for homepage redirect

### DIFF
--- a/tests/test_homepage.py
+++ b/tests/test_homepage.py
@@ -1,0 +1,38 @@
+import sys
+import types
+from flask import Blueprint
+
+# Stub auth blueprint
+auth_module = types.ModuleType('dataqe_app.auth.routes')
+auth_bp = Blueprint('auth', __name__)
+
+@auth_bp.route('/login')
+def login():
+    return 'login'
+
+auth_module.auth_bp = auth_bp
+sys.modules.setdefault('dataqe_app.auth', types.ModuleType('dataqe_app.auth'))
+sys.modules['dataqe_app.auth.routes'] = auth_module
+
+# Stub DataQEBridge to avoid heavy dependencies
+bridge_module = types.ModuleType('dataqe_app.bridge.dataqe_bridge')
+class DataQEBridge:
+    def __init__(self, app=None):
+        self.app = app
+    def init_app(self, app):
+        self.app = app
+    def execute_test_case(self, *a, **kw):
+        return {"status": "SUCCESS"}
+bridge_module.DataQEBridge = DataQEBridge
+sys.modules.setdefault('dataqe_app.bridge', types.ModuleType('dataqe_app.bridge'))
+sys.modules['dataqe_app.bridge.dataqe_bridge'] = bridge_module
+
+from dataqe_app import create_app
+
+
+def test_home_redirect():
+    app = create_app()
+    with app.test_client() as client:
+        response = client.get('/')
+        assert response.status_code == 302
+        assert 'login' in response.headers.get('Location', '')


### PR DESCRIPTION
## Summary
- add `tests/test_homepage.py` to test homepage redirects to login
- include empty `tests/__init__.py` so pytest collects tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a4f259b88323b141d43f4ffdcf80