### PR TITLE
Fix blueprint url_for in templates

### DIFF
--- a/dataqe_app/templates/execution_history.html
+++ b/dataqe_app/templates/execution_history.html
@@ -112,10 +112,10 @@
                                     </td>
                                     <td>{{ execution.executor.username if execution.executor else 'System' }}</td>
                                     <td>
-                                        <a href="{{ url_for('execution_detail', execution_id=execution.id) }}" 
+                                        <a href="{{ url_for('executions.execution_detail', execution_id=execution.id) }}"
                                            class="btn btn-sm btn-outline-primary">
-                                            Details
-                                        </a>
+                                           Details
+                                       </a>
                                     </td>
                                 </tr>
                                 {% else %}
@@ -135,7 +135,7 @@
                         <ul class="pagination mb-0">
                             {% if executions.has_prev %}
                             <li class="page-item">
-                                <a class="page-link" href="{{ url_for('execution_history', page=executions.prev_num) }}">Previous</a>
+                                <a class="page-link" href="{{ url_for('executions.execution_history', page=executions.prev_num) }}">Previous</a>
                             </li>
                             {% else %}
                             <li class="page-item disabled">
@@ -147,7 +147,7 @@
                                 {% if page_num %}
                                     {% if page_num != executions.page %}
                                     <li class="page-item">
-                                        <a class="page-link" href="{{ url_for('execution_history', page=page_num) }}">{{ page_num }}</a>
+                                        <a class="page-link" href="{{ url_for('executions.execution_history', page=page_num) }}">{{ page_num }}</a>
                                     </li>
                                     {% else %}
                                     <li class="page-item active">
@@ -163,7 +163,7 @@
                             
                             {% if executions.has_next %}
                             <li class="page-item">
-                                <a class="page-link" href="{{ url_for('execution_history', page=executions.next_num) }}">Next</a>
+                                <a class="page-link" href="{{ url_for('executions.execution_history', page=executions.next_num) }}">Next</a>
                             </li>
                             {% else %}
                             <li class="page-item disabled">

--- a/dataqe_app/templates/results_dashboard.html
+++ b/dataqe_app/templates/results_dashboard.html
@@ -127,7 +127,7 @@
                                                 {% endif %}
                                             </td>
                                             <td>
-                                                <a href="{{ url_for('execution_detail', execution_id=execution.id) }}" 
+                                                <a href="{{ url_for('executions.execution_detail', execution_id=execution.id) }}"
                                                    class="btn btn-sm btn-outline-primary">
                                                     View Details
                                                 </a>


### PR DESCRIPTION
## Summary
- ensure execution detail and history links use blueprint prefix

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a6eb8f9883239d32d97b945a6658