### PR TITLE
Remove duplicate create_schedule endpoint

### DIFF
--- a/dataqe_app/scheduler/routes.py
+++ b/dataqe_app/scheduler/routes.py
@@ -1,56 +1,7 @@
-from flask import Blueprint, render_template, request, redirect, url_for, flash
-from flask_login import login_required, current_user
-from dataqe_app import db
-from dataqe_app.models import TestCase, ScheduledTest
-from apscheduler.triggers.cron import CronTrigger
-from dataqe_app.utils.helpers import run_scheduled_test
-import uuid
+"""Blueprint placeholder for future scheduler related routes."""
 
-scheduler_bp = Blueprint('scheduler', __name__)
+from flask import Blueprint
 
-@scheduler_bp.route('/schedule/create/<int:test_case_id>', methods=['GET', 'POST'])
-@login_required
-def create_schedule(test_case_id):
-    test_case = TestCase.query.get_or_404(test_case_id)
+# The actual schedule creation endpoint lives in ``testcases/routes.py``.
+scheduler_bp = Blueprint("scheduler", __name__)
 
-    if not current_user.is_admin and current_user.team_id != test_case.team_id:
-        flash('Access denied')
-        return redirect(url_for('dashboard'))
-
-    if request.method == 'POST':
-        schedule_type = request.form.get('schedule_type')
-        schedule_time = request.form.get('schedule_time')
-        schedule_days = request.form.get('schedule_days', '')
-
-        schedule = ScheduledTest(
-            test_case_id=test_case_id,
-            schedule_type=schedule_type,
-            schedule_time=schedule_time,
-            schedule_days=schedule_days,
-            created_by=current_user.id
-        )
-
-        hour, minute = schedule_time.split(':')
-        if schedule_type == 'DAILY':
-            trigger = CronTrigger(hour=int(hour), minute=int(minute))
-        elif schedule_type == 'WEEKLY':
-            days = schedule_days.split(',')
-            trigger = CronTrigger(day_of_week=','.join(days), hour=int(hour), minute=int(minute))
-
-        from dataqe_app import scheduler
-        job_id = f'test_{test_case_id}_{uuid.uuid4().hex}'
-        scheduler.add_job(
-            func=run_scheduled_test,
-            trigger=trigger,
-            args=[test_case_id],
-            id=job_id,
-            replace_existing=True
-        )
-
-        db.session.add(schedule)
-        db.session.commit()
-
-        flash('Schedule created successfully')
-        return redirect(url_for('testcase_detail', testcase_id=test_case_id))
-
-    return render_template('create_schedule.html', test_case=test_case)

--- a/dataqe_app/templates/testcase_detail.html
+++ b/dataqe_app/templates/testcase_detail.html
@@ -86,7 +86,7 @@
                             data-bs-target="#executeModal">
                         <i class="bi bi-play-circle"></i> Execute
                     </button>
-                    <a href="{{ url_for('scheduler.create_schedule', test_case_id=test_case.id) }}"
+                    <a href="{{ url_for('testcases.create_schedule', test_case_id=test_case.id) }}"
                        class="btn btn-outline-primary me-2">
                         <i class="bi bi-clock"></i> Schedule
                     </a>


### PR DESCRIPTION
## Summary
- keep `create_schedule` in `testcases` blueprint
- drop duplicate from the scheduler blueprint
- fix link in `testcase_detail.html`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a80fe36083239abcd15e2e067216