### PR TITLE
Add docstring search utility

### DIFF
--- a/core/docstring_search.py
+++ b/core/docstring_search.py
@@ -1,0 +1,42 @@
+import importlib
+import inspect
+from typing import List, Dict
+
+
+def collect_docstrings(module_names: List[str]) -> Dict[str, str]:
+    """Collect docstrings from modules, classes and functions."""
+    docs: Dict[str, str] = {}
+    for name in module_names:
+        try:
+            module = importlib.import_module(name)
+        except Exception:
+            # Skip modules that fail to import
+            continue
+
+        module_doc = inspect.getdoc(module)
+        if module_doc:
+            docs[name] = module_doc
+
+        for member_name, member in inspect.getmembers(module):
+            if inspect.isfunction(member) or inspect.isclass(member):
+                doc = inspect.getdoc(member)
+                if doc:
+                    docs[f"{name}.{member_name}"] = doc
+            if inspect.isclass(member):
+                for attr_name, attr in inspect.getmembers(member):
+                    if inspect.isfunction(attr) or inspect.ismethod(attr):
+                        doc = inspect.getdoc(attr)
+                        if doc:
+                            docs[f"{name}.{member_name}.{attr_name}"] = doc
+    return docs
+
+
+def search_docstrings(query: str, module_names: List[str]) -> Dict[str, str]:
+    """Return docstrings containing the query string (case-insensitive)."""
+    all_docs = collect_docstrings(module_names)
+    query_lower = query.lower()
+    return {
+        name: doc
+        for name, doc in all_docs.items()
+        if query_lower in doc.lower()
+    }

--- a/doc_search.py
+++ b/doc_search.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Simple CLI to search docstrings for a query."""
+import argparse
+from core.docstring_search import search_docstrings
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Search docstrings")
+    parser.add_argument("query", help="Text to search for")
+    parser.add_argument(
+        "modules",
+        nargs="*",
+        default=["core"],
+        help="Modules to search (default: core)",
+    )
+    args = parser.parse_args()
+
+    results = search_docstrings(args.query, args.modules)
+    if not results:
+        print("No matches found.")
+        return
+
+    for name, doc in results.items():
+        print(f"{name}\n{doc}\n{'-' * 40}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_docstring_search.py
+++ b/tests/test_docstring_search.py
@@ -1,0 +1,6 @@
+import core.docstring_search as ds
+
+
+def test_search_read_csv_docstring():
+    results = ds.search_docstrings("read a csv file", ["core.file_parsing"])
+    assert any("CSVFileParser.read_csv" in name for name in results)


### PR DESCRIPTION
## Summary
- implement `core.docstring_search` for indexing docstrings
- provide a small CLI `doc_search.py`
- test searching for docstrings in `core.file_parsing`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_6844c0d6ec188323af850f57dbb40272