### PR TITLE
Fix project links in templates

### DIFF
--- a/dataqe_app/templates/connection_new.html
+++ b/dataqe_app/templates/connection_new.html
@@ -10,20 +10,13 @@
             <nav aria-label="breadcrumb">
                 <ol class="breadcrumb">
                     <li class="breadcrumb-item"><a href="{{ url_for('dashboard') }}">Dashboard</a></li>
-   {% if current_user.is_authenticated %}
+                    {% if current_user.is_authenticated %}
                         {% if current_user.is_admin %}
                             <li class="breadcrumb-item"><a href="{{ url_for('projects.projects') }}">Projects</a></li>
                             <li class="breadcrumb-item"><a href="{{ url_for('projects.project_detail', project_id=project.id) }}">{{ project.name }}</a></li>
                         {% else %}
                             <li class="breadcrumb-item"><a href="{{ url_for('team_detail', team_id=current_user.team.id) }}">{{ current_user.team.name }}</a></li>
                         {% endif %}
-
-                    {% if current_user.is_admin %}
-                    <li class="breadcrumb-item"><a href="{{ url_for('projects') }}">Projects</a></li>
-                    <li class="breadcrumb-item"><a href="{{ url_for('projects.project_detail', project_id=project.id) }}">{{ project.name }}</a></li>
-                    {% else %}
-                    <li class="breadcrumb-item"><a href="{{ url_for('team_detail', team_id=current_user.team.id) }}">{{ current_user.team.name }}</a></li>
-
                     {% endif %}
                     <li class="breadcrumb-item active">New Connection</li>
                 </ol>
@@ -79,15 +72,9 @@
                         </div>
                         
                         <div class="d-flex justify-content-between mt-4">
-
                             {% if current_user.is_authenticated and current_user.is_admin %}
                                 <a href="{{ url_for('projects.project_detail', project_id=project.id) }}" class="btn btn-outline-secondary">Cancel</a>
                             {% elif current_user.is_authenticated %}
-
-                            {% if current_user.is_admin %}
-                                <a href="{{ url_for('projects.project_detail', project_id=project.id) }}" class="btn btn-outline-secondary">Cancel</a>
-                            {% else %}
-
                                 <a href="{{ url_for('team_detail', team_id=current_user.team.id) }}" class="btn btn-outline-secondary">Cancel</a>
                             {% else %}
                                 <a href="{{ url_for('projects.project_detail', project_id=project.id) }}" class="btn btn-outline-secondary">Cancel</a>

--- a/dataqe_app/templates/team_detail.html
+++ b/dataqe_app/templates/team_detail.html
@@ -13,7 +13,7 @@
 
                     <li class="breadcrumb-item"><a href="{{ url_for('projects.projects') }}">Projects</a></li>
 
-                    <li class="breadcrumb-item"><a href="{{ url_for('projects') }}">Projects</a></li>
+                    <li class="breadcrumb-item"><a href="{{ url_for('projects.projects') }}">Projects</a></li>
 
                     <li class="breadcrumb-item"><a href="{{ url_for('projects.project_detail', project_id=team.project.id) }}">{{ team.project.name }}</a></li>
                     {% endif %}

--- a/dataqe_app/templates/team_new.html
+++ b/dataqe_app/templates/team_new.html
@@ -12,7 +12,7 @@
 
                     <li class="breadcrumb-item"><a href="{{ url_for('projects.projects') }}">Projects</a></li>
 
-                    <li class="breadcrumb-item"><a href="{{ url_for('projects') }}">Projects</a></li>
+                    <li class="breadcrumb-item"><a href="{{ url_for('projects.projects') }}">Projects</a></li>
 
                     <li class="breadcrumb-item"><a href="{{ url_for('projects.project_detail', project_id=project.id) }}">{{ project.name }}</a></li>
                     <li class="breadcrumb-item active">New Team</li>

--- a/dataqe_app/templates/testcase_new.html
+++ b/dataqe_app/templates/testcase_new.html
@@ -19,7 +19,7 @@
 
                     <li class="breadcrumb-item"><a href="{{ url_for('projects.projects') }}">Projects</a></li>
 
-                    <li class="breadcrumb-item"><a href="{{ url_for('projects') }}">Projects</a></li>
+                    <li class="breadcrumb-item"><a href="{{ url_for('projects.projects') }}">Projects</a></li>
 
                     <li class="breadcrumb-item"><a href="{{ url_for('projects.project_detail', project_id=team.project.id) }}">{{ team.project.name }}</a></li>
                     <li class="breadcrumb-item"><a href="{{ url_for('team_detail', team_id=team.id) }}">{{ team.name }}</a></li>


### PR DESCRIPTION
## Summary
- use `projects.projects` endpoint when linking to projects page
- simplify breadcrumbs and cancel button logic for connection form
- run tests

## Testing
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_6844e7847e788323929016b79041175b