### PR TITLE
Fix NoneType description on projects page

### DIFF
--- a/dataqe_app/templates/projects.html
+++ b/dataqe_app/templates/projects.html
@@ -36,7 +36,7 @@
                                 {% for project in projects %}
                                 <tr>
                                     <td>{{ project.name }}</td>
-                                    <td>{{ project.description[:50] }}{% if project.description and project.description|length > 50 %}...{% endif %}</td>
+                                    <td>{{ project.description[:50] if project.description else '' }}{% if project.description and project.description|length > 50 %}...{% endif %}</td>
                                     <td>
                                         <span class="text-truncate d-inline-block" style="max-width: 200px;" title="{{ project.folder_path or 'N/A' }}">
                                             {{ project.folder_path or 'N/A' }}


### PR DESCRIPTION
## Summary
- handle `None` project descriptions when listing projects

## Testing
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_6845dc66579883238e21a2b29a4c5e8e