### PR TITLE
Fix NoneType description on projects page

### DIFF
--- a/dataqe_app/projects/routes.py
+++ b/dataqe_app/projects/routes.py
@@ -71,3 +71,13 @@ def new_connection(project_id):
             return redirect(url_for('projects.project_detail', project_id=project.id))
     return render_template('connection_new.html', project=project)
 
+
+@projects_bp.route('/projects/<int:project_id>/delete', methods=['POST'])
+def delete_project(project_id):
+    """Delete a project and its connections."""
+    project = Project.query.get_or_404(project_id)
+    Connection.query.filter_by(project_id=project_id).delete()
+    db.session.delete(project)
+    db.session.commit()
+    return redirect(url_for('projects.projects'))
+

--- a/dataqe_app/templates/project_detail.html
+++ b/dataqe_app/templates/project_detail.html
@@ -20,7 +20,8 @@
                     <p class="text-muted">{{ project.description }}</p>
                 </div>
                 <div>
-                    <a href="{{ url_for('projects.projects') }}" class="btn btn-outline-secondary">Back to Projects</a>
+                    <a href="{{ url_for('projects.projects') }}" class="btn btn-outline-secondary me-2">Back to Projects</a>
+                    <button type="button" class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#deleteProjectModal">Delete Project</button>
                 </div>
             </div>
             
@@ -174,6 +175,31 @@
                 </div>
             </div>
         </div>
+</div>
+</div>
+
+<!-- Delete Project Modal -->
+<div class="modal fade" id="deleteProjectModal" tabindex="-1" aria-labelledby="deleteProjectModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="deleteProjectModalLabel">Confirm Delete</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <p>Are you sure you want to delete the project <strong>{{ project.name }}</strong>?</p>
+                <div class="alert alert-danger">
+                    <i class="bi bi-exclamation-triangle"></i> This action cannot be undone!
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <form action="{{ url_for('projects.delete_project', project_id=project.id) }}" method="post">
+                    <button type="submit" class="btn btn-danger">Delete Project</button>
+                </form>
+            </div>
+        </div>
     </div>
 </div>
+
 {% endblock %}

--- a/dataqe_app/templates/projects.html
+++ b/dataqe_app/templates/projects.html
@@ -36,7 +36,7 @@
                                 {% for project in projects %}
                                 <tr>
                                     <td>{{ project.name }}</td>
-                                    <td>{{ project.description[:50] }}{% if project.description and project.description|length > 50 %}...{% endif %}</td>
+                                    <td>{{ project.description[:50] if project.description else '' }}{% if project.description and project.description|length > 50 %}...{% endif %}</td>
                                     <td>
                                         <span class="text-truncate d-inline-block" style="max-width: 200px;" title="{{ project.folder_path or 'N/A' }}">
                                             {{ project.folder_path or 'N/A' }}

--- a/tests/test_connection_save.py
+++ b/tests/test_connection_save.py
@@ -62,7 +62,7 @@ def test_connection_creation():
         assert resp.status_code == 200
 
     with app.app_context():
-        conn = Connection.query.filter_by(name='TestConn').first()
+        conn = Connection.query.filter_by(name='TestConn').order_by(Connection.id.desc()).first()
         assert conn is not None
         assert conn.project_id == pid
         assert conn.server == 'srv'

--- a/tests/test_project_detail.py
+++ b/tests/test_project_detail.py
@@ -66,6 +66,7 @@ def test_project_detail_page():
         response = client.get(f'/projects/{pid}')
         assert response.status_code == 200
         assert b'Demo Project' in response.data
+        assert b'Delete Project' in response.data
 
 
 
@@ -100,5 +101,22 @@ def test_new_connection_route():
         assert resp.status_code == 200
         resp = client.post(f'/connections/new/{pid}', data={'name': 'conn'}, follow_redirects=True)
         assert resp.status_code == 200
+
+
+def test_delete_project_route():
+    app = create_app()
+
+    with app.app_context():
+        db.create_all()
+        project = Project(name='Delete Me')
+        db.session.add(project)
+        db.session.commit()
+        pid = project.id
+
+    with app.test_client() as client:
+        resp = client.post(f'/projects/{pid}/delete', follow_redirects=True)
+        assert resp.status_code == 200
+        with app.app_context():
+            assert Project.query.get(pid) is None
 
 


### PR DESCRIPTION
## Summary
- handle `None` project descriptions when listing projects
- add project deletion route
- add delete project button and modal on manage screen
- test project deletion and fix connection tests

## Testing
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_6845dc66579883238e21a2b29a4c5e8e