### PR TITLE
Implement team management page

### DIFF
--- a/dataqe_app/templates/team_detail.html
+++ b/dataqe_app/templates/team_detail.html
@@ -28,7 +28,7 @@
                 </div>
                 <div>
                     {% if current_user.is_admin %}
-                    <a href="{{ url_for('new_testcase') }}?team_id={{ team.id }}" class="btn btn-primary me-2">Add Test Case</a>
+                    <a href="{{ url_for('testcases.new_testcase') }}?team_id={{ team.id }}" class="btn btn-primary me-2">Add Test Case</a>
                     <a href="{{ url_for('projects.project_detail', project_id=team.project.id) }}" class="btn btn-outline-secondary">Back to Project</a>
                     {% else %}
                     <a href="{{ url_for('dashboard') }}" class="btn btn-outline-secondary">Back to Dashboard</a>
@@ -73,6 +73,7 @@
                                     </td>
                                     {% if current_user.is_admin %}
                                     <td>
+                                        <a href="{{ url_for('edit_user', user_id=user.id) }}" class="btn btn-sm btn-outline-primary me-1">Edit</a>
                                         <form action="{{ url_for('remove_team_member', team_id=team.id, user_id=user.id) }}" method="post" style="display: inline;">
                                             <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('Remove this user from the team?')">Remove</button>
                                         </form>
@@ -94,7 +95,7 @@
             <div class="card">
                 <div class="card-header d-flex justify-content-between align-items-center">
                     <h5 class="mb-0">Test Cases</h5>
-                    <a href="{{ url_for('new_testcase') }}?team_id={{ team.id }}" class="btn btn-sm btn-primary">Add Test Case</a>
+                    <a href="{{ url_for('testcases.new_testcase') }}?team_id={{ team.id }}" class="btn btn-sm btn-primary">Add Test Case</a>
                 </div>
                 <div class="card-body p-0">
                     <div class="table-responsive">
@@ -141,7 +142,7 @@
                                     <td>{{ test_case.creator.username if test_case.creator else 'Unknown' }}</td>
                                     <td>
                                         <a href="{{ url_for('testcase_detail', testcase_id=test_case.id) }}" class="btn btn-sm btn-outline-primary">View</a>
-                                        <a href="{{ url_for('edit_testcase', testcase_id=test_case.id) }}" class="btn btn-sm btn-outline-secondary">Edit</a>
+                                        <a href="{{ url_for('testcases.edit_testcase', testcase_id=test_case.id) }}" class="btn btn-sm btn-outline-secondary">Edit</a>
                                         <button type="button" class="btn btn-sm btn-outline-danger" onclick="confirmDelete({{ test_case.id }}, '{{ test_case.tcid }}')">Delete</button>
                                     </td>
                                 </tr>
@@ -149,7 +150,7 @@
                                 <tr>
                                     <td colspan="8" class="text-center">
                                         No test cases created yet.
-                                        <a href="{{ url_for('new_testcase') }}?team_id={{ team.id }}">Create your first test case</a>
+                                        <a href="{{ url_for('testcases.new_testcase') }}?team_id={{ team.id }}">Create your first test case</a>
                                     </td>
                                 </tr>
                                 {% endfor %}

--- a/dataqe_app/templates/testcase_detail.html
+++ b/dataqe_app/templates/testcase_detail.html
@@ -90,7 +90,7 @@
                        class="btn btn-outline-primary me-2">
                         <i class="bi bi-clock"></i> Schedule
                     </a>
-                    <a href="{{ url_for('edit_testcase', testcase_id=test_case.id) }}" class="btn btn-outline-primary me-2">
+                    <a href="{{ url_for('testcases.edit_testcase', testcase_id=test_case.id) }}" class="btn btn-outline-primary me-2">
                         <i class="bi bi-pencil"></i> Edit
                     </a>
                     <button type="button" class="btn btn-outline-danger me-2" data-bs-toggle="modal" data-bs-target="#deleteModal">

--- a/dataqe_app/templates/user_dashboard.html
+++ b/dataqe_app/templates/user_dashboard.html
@@ -33,7 +33,7 @@
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="{{ url_for('new_testcase') }}">
+                        <a class="nav-link" href="{{ url_for('testcases.new_testcase') }}">
                             <i class="bi bi-plus-circle"></i> New Test Case
                         </a>
                     </li>
@@ -53,7 +53,7 @@
                         <a href="{{ url_for('projects.new_connection', project_id=team.project.id) }}" class="btn btn-primary me-2">
                             <i class="bi bi-database-add"></i> New Connection
                         </a>
-                        <a href="{{ url_for('new_testcase') }}" class="btn btn-primary">
+                        <a href="{{ url_for('testcases.new_testcase') }}" class="btn btn-primary">
                             <i class="bi bi-plus-circle"></i> New Test Case
                         </a>
                     </div>
@@ -244,7 +244,7 @@
                                         <td>{{ test_case.created_at.strftime('%Y-%m-%d') }}</td>
                                         <td>
                                             <a href="{{ url_for('testcases.testcase_detail', testcase_id=test_case.id) }}" class="btn btn-sm btn-outline-primary">View</a>
-                                            <a href="{{ url_for('edit_testcase', testcase_id=test_case.id) }}" class="btn btn-sm btn-outline-secondary">Edit</a>
+                                            <a href="{{ url_for('testcases.edit_testcase', testcase_id=test_case.id) }}" class="btn btn-sm btn-outline-secondary">Edit</a>
                                             <button type="button" class="btn btn-sm btn-outline-danger" onclick="confirmDelete({{ test_case.id }}, '{{ test_case.tcid }}')">Delete</button>
                                         </td>
                                     </tr>
@@ -252,7 +252,7 @@
                                     <tr>
                                         <td colspan="6" class="text-center">
                                             No test cases created yet.
-                                            <a href="{{ url_for('new_testcase') }}">Create your first test case</a>
+                                            <a href="{{ url_for('testcases.new_testcase') }}">Create your first test case</a>
                                         </td>
                                     </tr>
                                     {% endfor %}

--- a/dataqe_app/testcases/routes.py
+++ b/dataqe_app/testcases/routes.py
@@ -118,3 +118,27 @@ def debug_last_execution():
             'end_time': execution.end_time.isoformat() if execution.end_time else None
         })
     return jsonify({'error': 'No executions found'})
+
+
+@testcases_bp.route('/testcase/new', methods=['GET', 'POST'], endpoint='new_testcase')
+def new_testcase():
+    """Placeholder for creating a new test case."""
+    if request.method == 'POST':
+        # For now simply acknowledge the post and redirect back
+        flash('Test case creation not implemented', 'info')
+        team_id = request.args.get('team_id') or request.form.get('team_id')
+        if team_id:
+            return redirect(url_for('team_detail', team_id=team_id))
+        return redirect(url_for('dashboard'))
+
+    return render_template('placeholder.html', title='New Test Case')
+
+
+@testcases_bp.route('/testcase/<int:testcase_id>/edit', methods=['GET', 'POST'], endpoint='edit_testcase')
+def edit_testcase(testcase_id):
+    """Placeholder for editing a test case."""
+    if request.method == 'POST':
+        flash('Editing test cases is not implemented', 'info')
+        return redirect(url_for('testcase_detail', testcase_id=testcase_id))
+
+    return render_template('placeholder.html', title='Edit Test Case')

--- a/tests/test_team_detail.py
+++ b/tests/test_team_detail.py
@@ -1,0 +1,126 @@
+import sys
+import types
+from flask import Blueprint
+
+# Stub auth blueprint
+auth_module = types.ModuleType('dataqe_app.auth.routes')
+auth_bp = Blueprint('auth', __name__)
+
+@auth_bp.route('/login')
+def login():
+    return 'login'
+
+auth_module.auth_bp = auth_bp
+sys.modules.setdefault('dataqe_app.auth', types.ModuleType('dataqe_app.auth'))
+sys.modules['dataqe_app.auth.routes'] = auth_module
+
+# Stub DataQEBridge
+bridge_module = types.ModuleType('dataqe_app.bridge.dataqe_bridge')
+class DataQEBridge:
+    def __init__(self, app=None):
+        self.app = app
+    def init_app(self, app):
+        self.app = app
+    def execute_test_case(self, *a, **kw):
+        return {"status": "SUCCESS"}
+bridge_module.DataQEBridge = DataQEBridge
+sys.modules.setdefault('dataqe_app.bridge', types.ModuleType('dataqe_app.bridge'))
+sys.modules['dataqe_app.bridge.dataqe_bridge'] = bridge_module
+
+import apscheduler.schedulers.background
+apscheduler.schedulers.background.BackgroundScheduler.start = lambda self, *a, **k: None
+
+from dataqe_app import create_app, db, login_manager
+
+@login_manager.user_loader
+def load_user(user_id):
+    return None
+
+from dataqe_app.models import Project, Team, User
+
+
+def test_team_detail_page():
+    app = create_app()
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        project = Project(name='Demo')
+        team = Team(name='Alpha')
+        db.session.add_all([project, team])
+        db.session.commit()
+        project.team_id = team.id
+        user = User(username='u1', email='u1@example.com')
+        user.set_password('pass')
+        user.team_id = team.id
+        db.session.add(user)
+        db.session.commit()
+        tid = team.id
+
+    with app.test_client() as client:
+        resp = client.get(f'/teams/{tid}')
+        assert resp.status_code == 200
+        assert b'Alpha' in resp.data
+        assert b'u1@example.com' in resp.data
+
+
+def test_add_member_route():
+    app = create_app()
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        team = Team(name='Beta')
+        user = User(username='u2', email='u2@example.com')
+        user.set_password('pwd')
+        db.session.add_all([team, user])
+        db.session.commit()
+        tid = team.id
+        uid = user.id
+
+    with app.test_client() as client:
+        resp = client.post(f'/teams/{tid}/add_member', data={'user_id': uid}, follow_redirects=True)
+        assert resp.status_code == 200
+        with app.app_context():
+            assert User.query.get(uid).team_id == tid
+
+
+def test_remove_member_route():
+    app = create_app()
+    with app.app_context():
+        db.create_all()
+        team = Team(name='Gamma')
+        user = User(username='u3', email='u3@example.com')
+        user.set_password('pwd3')
+        db.session.add_all([team, user])
+        db.session.commit()
+        user.team_id = team.id
+        db.session.commit()
+        tid = team.id
+        uid = user.id
+
+    with app.test_client() as client:
+        resp = client.post(f'/teams/{tid}/remove_member/{uid}', follow_redirects=True)
+        assert resp.status_code == 200
+        with app.app_context():
+            assert User.query.get(uid).team_id is None
+
+
+def test_edit_user_route():
+    app = create_app()
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        user = User(username='old', email='old@example.com')
+        user.set_password('pwd')
+        db.session.add(user)
+        db.session.commit()
+        uid = user.id
+
+    with app.test_client() as client:
+        resp = client.post(
+            f'/users/{uid}/edit',
+            data={'username': 'new', 'email': 'new@example.com', 'password': 'newpwd', 'team_id': '', 'is_admin': ''},
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        with app.app_context():
+            assert User.query.get(uid).username == 'new'


### PR DESCRIPTION
## Summary
- finish team detail page routing
- add member management endpoints
- implement user CRUD routes
- show edit/remove buttons for team members
- define placeholder routes for new/edit test case and update templates
- test team routes

## Testing
- `pip install -r requirements.txt`
- `pytest -q tests`


------
https://chatgpt.com/codex/tasks/task_e_6845e63ebbd083239bd01d2f2fb9c202