### PR TITLE
Add test case CRUD

### DIFF
--- a/dataqe_app/models.py
+++ b/dataqe_app/models.py
@@ -58,7 +58,18 @@ class TestCase(db.Model):
     delimiter = db.Column(db.String(10))
     pk_columns = db.Column(db.String(255))
     date_fields = db.Column(db.String(255))
+    percentage_fields = db.Column(db.String(255))
+    threshold_percentage = db.Column(db.Float)
+    src_sheet_name = db.Column(db.String(255))
+    tgt_sheet_name = db.Column(db.String(255))
+    header_columns = db.Column(db.String(255))
+    skip_rows = db.Column(db.String(255))
+    creator_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    created_at = db.Column(db.DateTime, default=db.func.current_timestamp())
+    updated_at = db.Column(db.DateTime, default=db.func.current_timestamp(), onupdate=db.func.current_timestamp())
+    creator = db.relationship('User', foreign_keys=[creator_id])
     team_id = db.Column(db.Integer, db.ForeignKey('team.id'))
+    team = db.relationship('Team', backref='test_cases')
 
 class TestExecution(db.Model):
     id = db.Column(db.Integer, primary_key=True)

--- a/dataqe_app/templates/user_new.html
+++ b/dataqe_app/templates/user_new.html
@@ -8,8 +8,8 @@
         <div class="col-12">
             <nav aria-label="breadcrumb">
                 <ol class="breadcrumb">
-                    <li class="breadcrumb-item"><a href="{{ url_for('dashboard') }}">Dashboard</a></li>
-                    <li class="breadcrumb-item"><a href="{{ url_for('users') }}">Users</a></li>
+                    <li class="breadcrumb-item"><a href="{{ url_for('main.dashboard') }}">Dashboard</a></li>
+                    <li class="breadcrumb-item"><a href="{{ url_for('main.users') }}">Users</a></li>
                     <li class="breadcrumb-item active">New User</li>
                 </ol>
             </nav>
@@ -57,7 +57,7 @@
                         </div>
                         
                         <div class="d-flex justify-content-between mt-4">
-                            <a href="{{ url_for('users') }}" class="btn btn-outline-secondary">Cancel</a>
+                            <a href="{{ url_for('main.users') }}" class="btn btn-outline-secondary">Cancel</a>
                             <button type="submit" class="btn btn-primary">Create User</button>
                         </div>
                     </form>

--- a/dataqe_app/testcases/routes.py
+++ b/dataqe_app/testcases/routes.py
@@ -1,11 +1,12 @@
-from flask import Blueprint, render_template, request, redirect, url_for, flash, jsonify
+from flask import Blueprint, render_template, request, redirect, url_for, flash, jsonify, current_app
 from flask_login import login_required, current_user
 from dataqe_app import db
-from dataqe_app.models import TestCase, ScheduledTest, TestExecution, TestMismatch, User
+from dataqe_app.models import TestCase, ScheduledTest, TestExecution, TestMismatch, User, Team
 from dataqe_app.utils.helpers import run_scheduled_test
 from datetime import datetime
 import os
 import uuid
+from werkzeug.utils import secure_filename
 from apscheduler.triggers.cron import CronTrigger
 
 
@@ -121,24 +122,147 @@ def debug_last_execution():
 
 
 @testcases_bp.route('/testcase/new', methods=['GET', 'POST'], endpoint='new_testcase')
+@login_required
 def new_testcase():
-    """Placeholder for creating a new test case."""
-    if request.method == 'POST':
-        # For now simply acknowledge the post and redirect back
-        flash('Test case creation not implemented', 'info')
-        team_id = request.args.get('team_id') or request.form.get('team_id')
-        if team_id:
-            return redirect(url_for('team_detail', team_id=team_id))
+    """Create a new test case."""
+    team_id = request.args.get('team_id') or request.form.get('team_id') or current_user.team_id
+    if not team_id:
+        flash('Team not specified', 'error')
         return redirect(url_for('dashboard'))
 
-    return render_template('placeholder.html', title='New Test Case')
+    team = Team.query.get_or_404(team_id)
+
+    if not current_user.is_admin and current_user.team_id != team.id:
+        flash('Access denied', 'error')
+        return redirect(url_for('dashboard'))
+
+    connections = team.project.connections if team.project else []
+
+    if request.method == 'POST':
+        tcid = request.form.get('tcid')
+        table_name = request.form.get('table_name')
+        test_type = request.form.get('test_type')
+        tc_name = request.form.get('tc_name')
+        test_yn = 'Y' if request.form.get('test_yn') else 'N'
+        src_conn_id = request.form.get('src_connection_id') or None
+        tgt_conn_id = request.form.get('tgt_connection_id') or None
+        delimiter = request.form.get('delimiter')
+        filters = request.form.get('filters')
+        pk_columns = request.form.get('pk_columns')
+        date_fields = request.form.get('date_fields')
+        percentage_fields = request.form.get('percentage_fields')
+        threshold_percentage = request.form.get('threshold_percentage')
+        header_columns = request.form.get('header_columns')
+        skip_rows = request.form.get('skip_rows')
+        src_sheet_name = request.form.get('src_sheet_name')
+        tgt_sheet_name = request.form.get('tgt_sheet_name')
+
+        project_input_folder = os.path.join(team.project.folder_path, 'input') if team.project else current_app.config['UPLOAD_FOLDER']
+        os.makedirs(project_input_folder, exist_ok=True)
+
+        src_file = request.files.get('src_file')
+        tgt_file = request.files.get('tgt_file')
+        src_data_file = None
+        tgt_data_file = None
+        if src_file and src_file.filename:
+            filename = f"{uuid.uuid4().hex}_{secure_filename(src_file.filename)}"
+            src_file.save(os.path.join(project_input_folder, filename))
+            src_data_file = filename
+        if tgt_file and tgt_file.filename:
+            filename = f"{uuid.uuid4().hex}_{secure_filename(tgt_file.filename)}"
+            tgt_file.save(os.path.join(project_input_folder, filename))
+            tgt_data_file = filename
+
+        test_case = TestCase(
+            tcid=tcid,
+            tc_name=tc_name,
+            table_name=table_name,
+            test_type=test_type,
+            test_yn=test_yn,
+            src_data_file=src_data_file,
+            tgt_data_file=tgt_data_file,
+            src_connection_id=src_conn_id,
+            tgt_connection_id=tgt_conn_id,
+            filters=filters,
+            delimiter=delimiter,
+            pk_columns=pk_columns,
+            date_fields=date_fields,
+            percentage_fields=percentage_fields,
+            threshold_percentage=threshold_percentage,
+            header_columns=header_columns,
+            skip_rows=skip_rows,
+            src_sheet_name=src_sheet_name,
+            tgt_sheet_name=tgt_sheet_name,
+            team_id=team.id,
+            creator_id=current_user.id,
+        )
+        db.session.add(test_case)
+        db.session.commit()
+
+        flash('Test case created successfully', 'success')
+        return redirect(url_for('team_detail', team_id=team.id))
+
+    return render_template('testcase_new.html', team=team, connections=connections)
 
 
 @testcases_bp.route('/testcase/<int:testcase_id>/edit', methods=['GET', 'POST'], endpoint='edit_testcase')
+@login_required
 def edit_testcase(testcase_id):
-    """Placeholder for editing a test case."""
-    if request.method == 'POST':
-        flash('Editing test cases is not implemented', 'info')
-        return redirect(url_for('testcase_detail', testcase_id=testcase_id))
+    """Edit an existing test case."""
+    test_case = TestCase.query.get_or_404(testcase_id)
 
-    return render_template('placeholder.html', title='Edit Test Case')
+    if not current_user.is_admin and current_user.team_id != test_case.team_id:
+        flash('Access denied', 'error')
+        return redirect(url_for('dashboard'))
+
+    team = test_case.team
+    connections = team.project.connections if team and team.project else []
+
+    if request.method == 'POST':
+        test_case.tcid = request.form.get('tcid')
+        test_case.table_name = request.form.get('table_name')
+        test_case.test_type = request.form.get('test_type')
+        test_case.tc_name = request.form.get('tc_name')
+        test_case.test_yn = 'Y' if request.form.get('test_yn') else 'N'
+        test_case.src_connection_id = request.form.get('src_connection_id') or None
+        test_case.tgt_connection_id = request.form.get('tgt_connection_id') or None
+        test_case.delimiter = request.form.get('delimiter')
+        test_case.filters = request.form.get('filters')
+        test_case.pk_columns = request.form.get('pk_columns')
+        test_case.date_fields = request.form.get('date_fields')
+        test_case.percentage_fields = request.form.get('percentage_fields')
+        test_case.threshold_percentage = request.form.get('threshold_percentage')
+        test_case.header_columns = request.form.get('header_columns')
+        test_case.skip_rows = request.form.get('skip_rows')
+        test_case.src_sheet_name = request.form.get('src_sheet_name')
+        test_case.tgt_sheet_name = request.form.get('tgt_sheet_name')
+
+        project_input_folder = os.path.join(team.project.folder_path, 'input') if team and team.project else current_app.config['UPLOAD_FOLDER']
+        os.makedirs(project_input_folder, exist_ok=True)
+
+        src_file = request.files.get('src_file')
+        if src_file and src_file.filename:
+            if test_case.src_data_file:
+                old_path = os.path.join(project_input_folder, test_case.src_data_file)
+                if os.path.exists(old_path):
+                    os.remove(old_path)
+            filename = f"{uuid.uuid4().hex}_{secure_filename(src_file.filename)}"
+            src_file.save(os.path.join(project_input_folder, filename))
+            test_case.src_data_file = filename
+
+        tgt_file = request.files.get('tgt_file')
+        if tgt_file and tgt_file.filename:
+            if test_case.tgt_data_file:
+                old_path = os.path.join(project_input_folder, test_case.tgt_data_file)
+                if os.path.exists(old_path):
+                    os.remove(old_path)
+            filename = f"{uuid.uuid4().hex}_{secure_filename(tgt_file.filename)}"
+            tgt_file.save(os.path.join(project_input_folder, filename))
+            test_case.tgt_data_file = filename
+
+        db.session.commit()
+
+        flash('Test case updated successfully', 'success')
+        return redirect(url_for('testcase_detail', testcase_id=test_case.id))
+
+    return render_template('testcase_edit.html', team=team, test_case=test_case, connections=connections, src_sql=None, tgt_sql=None)

--- a/tests/test_testcase_routes.py
+++ b/tests/test_testcase_routes.py
@@ -1,0 +1,120 @@
+import sys
+import types
+import os
+from flask import Blueprint
+
+# Stub auth blueprint
+auth_module = types.ModuleType('dataqe_app.auth.routes')
+auth_bp = Blueprint('auth', __name__)
+@auth_bp.route('/login')
+def login():
+    return 'login'
+@auth_bp.route('/logout')
+def logout():
+    return 'logout'
+auth_module.auth_bp = auth_bp
+sys.modules.setdefault('dataqe_app.auth', types.ModuleType('dataqe_app.auth'))
+sys.modules['dataqe_app.auth.routes'] = auth_module
+
+# Stub DataQEBridge
+bridge_module = types.ModuleType('dataqe_app.bridge.dataqe_bridge')
+class DataQEBridge:
+    def __init__(self, app=None):
+        self.app = app
+    def init_app(self, app):
+        self.app = app
+    def execute_test_case(self, *a, **kw):
+        return {"status": "SUCCESS"}
+bridge_module.DataQEBridge = DataQEBridge
+sys.modules.setdefault('dataqe_app.bridge', types.ModuleType('dataqe_app.bridge'))
+sys.modules['dataqe_app.bridge.dataqe_bridge'] = bridge_module
+
+import apscheduler.schedulers.background
+apscheduler.schedulers.background.BackgroundScheduler.start = lambda self, *a, **k: None
+
+from dataqe_app import create_app, db, login_manager
+from dataqe_app.models import Project, Team, User, TestCase as TestCaseModel
+
+@login_manager.user_loader
+def load_user(user_id):
+    return User.query.get(int(user_id))
+
+def login(client, user_id):
+    with client.session_transaction() as sess:
+        sess['_user_id'] = str(user_id)
+
+
+def test_new_testcase_route(tmp_path):
+    app = create_app()
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        project_folder = tmp_path / "proj"
+        project_folder.mkdir(parents=True)
+        (project_folder / "input").mkdir()
+        project = Project(name='Demo', folder_path=str(project_folder))
+        team = Team(name='Team1')
+        db.session.add_all([project, team])
+        db.session.commit()
+        project.team_id = team.id
+        user = User(username='u', email='u@example.com')
+        user.set_password('pwd')
+        user.team_id = team.id
+        db.session.add(user)
+        db.session.commit()
+        uid = user.id
+        tid = team.id
+
+    with app.test_client() as client:
+        login(client, uid)
+        resp = client.post(f'/testcase/new?team_id={tid}', data={
+            'tcid': 'TC1',
+            'tc_name': 'Test',
+            'table_name': 'tbl',
+            'test_type': 'CCD_Validation',
+            'delimiter': ','
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+        with app.app_context():
+            tc = TestCaseModel.query.filter_by(tcid='TC1').first()
+            assert tc is not None
+            assert tc.team_id == tid
+
+
+def test_edit_testcase_route(tmp_path):
+    app = create_app()
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        proj_folder = tmp_path / "proj2"
+        proj_folder.mkdir(parents=True)
+        (proj_folder / "input").mkdir()
+        project = Project(name='Demo', folder_path=str(proj_folder))
+        team = Team(name='Team1')
+        db.session.add_all([project, team])
+        db.session.commit()
+        project.team_id = team.id
+        user = User(username='u', email='u@example.com')
+        user.set_password('pwd')
+        user.team_id = team.id
+        db.session.add(user)
+        db.session.commit()
+        tc = TestCaseModel(tcid='TC1', tc_name='Old', table_name='tbl', test_type='CCD_Validation', team_id=team.id)
+        db.session.add(tc)
+        db.session.commit()
+        uid = user.id
+        tcid = tc.id
+
+    with app.test_client() as client:
+        login(client, uid)
+        resp = client.post(f'/testcase/{tcid}/edit', data={
+            'tcid': 'TC1',
+            'tc_name': 'NewName',
+            'table_name': 'tbl2',
+            'test_type': 'CCD_Validation'
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+        with app.app_context():
+            updated = TestCaseModel.query.get(tcid)
+            assert updated.tc_name == 'NewName'
+            assert updated.table_name == 'tbl2'


### PR DESCRIPTION
## Summary
- extend `TestCase` model with metadata fields and team relationship
- implement creation and editing logic for test cases
- add unit tests for creating and editing test cases
- fix build error in add user page

## Testing
- `pip install -r requirements.txt`
- `pytest -q tests`


------
https://chatgpt.com/codex/tasks/task_e_6845ec81f6208323b4efe79809dd5f93