### PR TITLE
Switch teams to project-level user management

### DIFF
--- a/dataqe_app/projects/routes.py
+++ b/dataqe_app/projects/routes.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, render_template, request, redirect, url_for
 from dataqe_app import db
-from dataqe_app.models import Project, Team, Connection
+from dataqe_app.models import Project, Connection, User
 
 projects_bp = Blueprint('projects', __name__)
 
@@ -25,24 +25,11 @@ def new_project():
 @projects_bp.route('/projects/<int:project_id>')
 def project_detail(project_id):
     project = Project.query.get_or_404(project_id)
-    teams = [project.team] if getattr(project, 'team', None) else []
     connections = getattr(project, 'connections', [])
-    return render_template('project_detail.html', project=project, teams=teams, connections=connections)
+    users = project.users
+    available_users = User.query.filter(~User.projects.any(id=project_id)).all()
+    return render_template('project_detail.html', project=project, users=users, connections=connections, available_users=available_users)
 
-@projects_bp.route('/teams/new/<int:project_id>', methods=['GET', 'POST'])
-def new_team(project_id):
-    """Create a new team for the given project."""
-    project = Project.query.get_or_404(project_id)
-    if request.method == 'POST':
-        name = request.form.get('name')
-        if name:
-            team = Team(name=name)
-            db.session.add(team)
-            db.session.flush()
-            project.team_id = team.id
-            db.session.commit()
-            return redirect(url_for('projects.project_detail', project_id=project_id))
-    return render_template('team_new.html', project=project)
 
 
 @projects_bp.route('/connections/new/<int:project_id>', methods=['GET', 'POST'])
@@ -80,4 +67,27 @@ def delete_project(project_id):
     db.session.delete(project)
     db.session.commit()
     return redirect(url_for('projects.projects'))
+
+
+@projects_bp.route('/projects/<int:project_id>/add_member', methods=['POST'])
+def add_project_member(project_id):
+    """Assign an existing user to the project."""
+    user_id = request.form.get('user_id')
+    project = Project.query.get_or_404(project_id)
+    user = User.query.get_or_404(user_id)
+    if user not in project.users:
+        project.users.append(user)
+        db.session.commit()
+    return redirect(url_for('projects.project_detail', project_id=project_id))
+
+
+@projects_bp.route('/projects/<int:project_id>/remove_member/<int:user_id>', methods=['POST'])
+def remove_project_member(project_id, user_id):
+    """Remove a user from the project."""
+    project = Project.query.get_or_404(project_id)
+    user = User.query.get_or_404(user_id)
+    if user in project.users:
+        project.users.remove(user)
+        db.session.commit()
+    return redirect(url_for('projects.project_detail', project_id=project_id))
 

--- a/dataqe_app/templates/connection_new.html
+++ b/dataqe_app/templates/connection_new.html
@@ -11,12 +11,8 @@
                 <ol class="breadcrumb">
                     <li class="breadcrumb-item"><a href="{{ url_for('dashboard') }}">Dashboard</a></li>
                     {% if current_user.is_authenticated %}
-                        {% if current_user.is_admin %}
-                            <li class="breadcrumb-item"><a href="{{ url_for('projects.projects') }}">Projects</a></li>
-                            <li class="breadcrumb-item"><a href="{{ url_for('projects.project_detail', project_id=project.id) }}">{{ project.name }}</a></li>
-                        {% else %}
-                            <li class="breadcrumb-item"><a href="{{ url_for('team_detail', team_id=current_user.team.id) }}">{{ current_user.team.name }}</a></li>
-                        {% endif %}
+                        <li class="breadcrumb-item"><a href="{{ url_for('projects.projects') }}">Projects</a></li>
+                        <li class="breadcrumb-item"><a href="{{ url_for('projects.project_detail', project_id=project.id) }}">{{ project.name }}</a></li>
                     {% endif %}
                     <li class="breadcrumb-item active">New Connection</li>
                 </ol>
@@ -72,13 +68,7 @@
                         </div>
                         
                         <div class="d-flex justify-content-between mt-4">
-                            {% if current_user.is_authenticated and current_user.is_admin %}
-                                <a href="{{ url_for('projects.project_detail', project_id=project.id) }}" class="btn btn-outline-secondary">Cancel</a>
-                            {% elif current_user.is_authenticated %}
-                                <a href="{{ url_for('team_detail', team_id=current_user.team.id) }}" class="btn btn-outline-secondary">Cancel</a>
-                            {% else %}
-                                <a href="{{ url_for('projects.project_detail', project_id=project.id) }}" class="btn btn-outline-secondary">Cancel</a>
-                            {% endif %}
+                            <a href="{{ url_for('projects.project_detail', project_id=project.id) }}" class="btn btn-outline-secondary">Cancel</a>
                             <button type="submit" class="btn btn-primary">Create Connection</button>
                         </div>
                     </form>

--- a/dataqe_app/templates/project_detail.html
+++ b/dataqe_app/templates/project_detail.html
@@ -46,30 +46,30 @@
             </div>
             
             <div class="row">
-                <!-- Teams Section -->
+                <!-- Members Section -->
                 <div class="col-md-6 mb-4">
                     <div class="card h-100">
                         <div class="card-header d-flex justify-content-between align-items-center">
-                            <h5 class="mb-0">Teams</h5>
-                            <a href="{{ url_for('projects.new_team', project_id=project.id) }}" class="btn btn-sm btn-primary">Add Team</a>
+                            <h5 class="mb-0">Members</h5>
+                            <button class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#addMemberModal">Add Member</button>
                         </div>
                         <div class="card-body p-0">
                             <div class="list-group list-group-flush">
-                                {% for team in teams %}
-                                <a href="{{ url_for('team_detail', team_id=team.id) }}" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                                    {{ team.name }}
-                                    <span class="badge bg-primary rounded-pill">{{ team.test_cases|length }} test cases</span>
-                                </a>
-                                {% else %}
-                                <div class="list-group-item text-center text-muted">
-                                    No teams created yet
+                                {% for member in users %}
+                                <div class="list-group-item d-flex justify-content-between align-items-center">
+                                    {{ member.email }}
+                                    <form method="post" action="{{ url_for('projects.remove_project_member', project_id=project.id, user_id=member.id) }}">
+                                        <button class="btn btn-sm btn-outline-danger">Remove</button>
+                                    </form>
                                 </div>
+                                {% else %}
+                                <div class="list-group-item text-center text-muted">No members assigned</div>
                                 {% endfor %}
                             </div>
                         </div>
                     </div>
                 </div>
-                
+
                 <!-- Connections Section -->
                 <div class="col-md-6 mb-4">
                     <div class="card h-100">
@@ -103,79 +103,37 @@
                 </div>
             </div>
             
-            <!-- Team Activity Section -->
-            <div class="card mt-4">
-                <div class="card-header">
-                    <h5 class="mb-0">Test Case Overview</h5>
-                </div>
-                <div class="card-body">
-                    <div class="row">
-                        {% for team in teams %}
-                        <div class="col-md-6 col-lg-4 mb-4">
-                            <div class="card h-100">
-                                <div class="card-header bg-light">
-                                    <h6 class="mb-0">{{ team.name }}</h6>
-                                </div>
-                                <div class="card-body">
-                                    <div class="row text-center">
-                                        <div class="col-4">
-                                            <h5>{{ team.test_cases|length }}</h5>
-                                            <p class="text-muted small mb-0">Total</p>
-                                        </div>
-                                        <div class="col-4">
-                                            <h5>{{ team.test_cases|selectattr('test_yn', 'equalto', 'Y')|list|length }}</h5>
-                                            <p class="text-muted small mb-0">Active</p>
-                                        </div>
-                                        <div class="col-4">
-                                            <h5>{{ team.test_cases|selectattr('test_yn', 'equalto', 'N')|list|length }}</h5>
-                                            <p class="text-muted small mb-0">Inactive</p>
-                                        </div>
-                                    </div>
-                                    
-                                    <hr>
-                                    
-                                    <h6 class="mb-2">Test Types</h6>
-                                    <div class="mb-3">
-                                        {% set ccd_count = team.test_cases|selectattr('test_type', 'equalto', 'CCD_Validation')|list|length %}
-                                        {% set struct_count = team.test_cases|selectattr('test_type', 'equalto', 'Structure_Validation')|list|length %}
-                                        {% set dup_count = team.test_cases|selectattr('test_type', 'equalto', 'Duplicates_Check')|list|length %}
-                                        {% set const_count = team.test_cases|selectattr('test_type', 'equalto', 'Constraint_Check')|list|length %}
-                                        
-                                        {% if ccd_count > 0 %}
-                                        <span class="badge bg-primary me-1">CCD: {{ ccd_count }}</span>
-                                        {% endif %}
-                                        
-                                        {% if struct_count > 0 %}
-                                        <span class="badge bg-success me-1">Structure: {{ struct_count }}</span>
-                                        {% endif %}
-                                        
-                                        {% if dup_count > 0 %}
-                                        <span class="badge bg-warning me-1">Duplicates: {{ dup_count }}</span>
-                                        {% endif %}
-                                        
-                                        {% if const_count > 0 %}
-                                        <span class="badge bg-danger me-1">Constraint: {{ const_count }}</span>
-                                        {% endif %}
-                                    </div>
-                                    
-                                    <div class="text-center mt-3">
-                                        <a href="{{ url_for('team_detail', team_id=team.id) }}" class="btn btn-sm btn-outline-primary">View Team</a>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        {% else %}
-                        <div class="col-12">
-                            <div class="alert alert-info">
-                                No teams created yet. Add a team to start managing test cases.
-                            </div>
-                        </div>
-                        {% endfor %}
-                    </div>
-                </div>
-            </div>
         </div>
 </div>
+</div>
+
+<!-- Add Member Modal -->
+<div class="modal fade" id="addMemberModal" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Add Project Member</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <form action="{{ url_for('projects.add_project_member', project_id=project.id) }}" method="post">
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label for="user_id" class="form-label">Select User</label>
+                        <select class="form-select" id="user_id" name="user_id" required>
+                            <option value="">Choose a user...</option>
+                            {% for user in available_users %}
+                                <option value="{{ user.id }}">{{ user.username }} ({{ user.email }})</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Add Member</button>
+                </div>
+            </form>
+        </div>
+    </div>
 </div>
 
 <!-- Delete Project Modal -->

--- a/dataqe_app/templates/testcase_detail.html
+++ b/dataqe_app/templates/testcase_detail.html
@@ -65,10 +65,9 @@
             <nav aria-label="breadcrumb">
                 <ol class="breadcrumb">
                     <li class="breadcrumb-item"><a href="{{ url_for('main.dashboard') }}">Dashboard</a></li>
-                    {% if current_user.is_admin and test_case.team %}
+                    {% if current_user.is_admin and test_case.project %}
                     <li class="breadcrumb-item"><a href="{{ url_for('projects.projects') }}">Projects</a></li>
-                    <li class="breadcrumb-item"><a href="{{ url_for('projects.project_detail', project_id=test_case.team.project.id) }}">{{ test_case.team.project.name }}</a></li>
-                    <li class="breadcrumb-item"><a href="{{ url_for('team_detail', team_id=test_case.team.id) }}">{{ test_case.team.name }}</a></li>
+                    <li class="breadcrumb-item"><a href="{{ url_for('projects.project_detail', project_id=test_case.project.id) }}">{{ test_case.project.name }}</a></li>
                     {% endif %}
                     <li class="breadcrumb-item active">Test Case Details</li>
                 </ol>
@@ -96,9 +95,9 @@
                     <button type="button" class="btn btn-outline-danger me-2" data-bs-toggle="modal" data-bs-target="#deleteModal">
                         <i class="bi bi-trash"></i> Delete
                     </button>
-                    {% if current_user.is_admin and test_case.team %}
-                    <a href="{{ url_for('team_detail', team_id=test_case.team_id) }}" class="btn btn-outline-secondary">
-                        <i class="bi bi-arrow-left"></i> Back to Team
+                    {% if current_user.is_admin and test_case.project %}
+                    <a href="{{ url_for('projects.project_detail', project_id=test_case.project_id) }}" class="btn btn-outline-secondary">
+                        <i class="bi bi-arrow-left"></i> Back to Project
                     </a>
                     {% else %}
                     <a href="{{ url_for('main.dashboard') }}" class="btn btn-outline-secondary">

--- a/dataqe_app/templates/testcase_edit.html
+++ b/dataqe_app/templates/testcase_edit.html
@@ -11,8 +11,7 @@
                     <li class="breadcrumb-item"><a href="{{ url_for('dashboard') }}">Dashboard</a></li>
                     {% if current_user.is_admin %}
                     <li class="breadcrumb-item"><a href="{{ url_for('projects.projects') }}">Projects</a></li>
-                    <li class="breadcrumb-item"><a href="{{ url_for('projects.project_detail', project_id=team.project.id) }}">{{ team.project.name }}</a></li>
-                    <li class="breadcrumb-item"><a href="{{ url_for('team_detail', team_id=team.id) }}">{{ team.name }}</a></li>
+                    <li class="breadcrumb-item"><a href="{{ url_for('projects.project_detail', project_id=project.id) }}">{{ project.name }}</a></li>
                     {% endif %}
                     <li class="breadcrumb-item"><a href="{{ url_for('testcase_detail', testcase_id=test_case.id) }}">Test Case {{ test_case.tcid }}</a></li>
                     <li class="breadcrumb-item active">Edit</li>

--- a/dataqe_app/templates/testcase_new.html
+++ b/dataqe_app/templates/testcase_new.html
@@ -21,8 +21,7 @@
 
                     <li class="breadcrumb-item"><a href="{{ url_for('projects.projects') }}">Projects</a></li>
 
-                    <li class="breadcrumb-item"><a href="{{ url_for('projects.project_detail', project_id=team.project.id) }}">{{ team.project.name }}</a></li>
-                    <li class="breadcrumb-item"><a href="{{ url_for('team_detail', team_id=team.id) }}">{{ team.name }}</a></li>
+                    <li class="breadcrumb-item"><a href="{{ url_for('projects.project_detail', project_id=project.id) }}">{{ project.name }}</a></li>
                     {% endif %}
                     <li class="breadcrumb-item active">New Test Case</li>
                 </ol>
@@ -237,11 +236,7 @@
                         </div>
                         
                         <div class="d-grid gap-2 d-md-flex justify-content-md-end">
-                            {% if current_user.is_admin %}
-                            <a href="{{ url_for('team_detail', team_id=team.id) }}" class="btn btn-outline-secondary">Cancel</a>
-                            {% else %}
-                            <a href="{{ url_for('dashboard') }}" class="btn btn-outline-secondary">Cancel</a>
-                            {% endif %}
+                            <a href="{{ url_for('projects.project_detail', project_id=project.id) }}" class="btn btn-outline-secondary">Cancel</a>
                             <button type="submit" class="btn btn-primary">Create Test Case</button>
                         </div>
                     </form>

--- a/dataqe_app/templates/user_edit.html
+++ b/dataqe_app/templates/user_edit.html
@@ -36,15 +36,10 @@
                         </div>
                         
                         <div class="mb-3">
-                            <label for="team_id" class="form-label">Assign to Team</label>
-                            <select class="form-select" id="team_id" name="team_id">
-                                <option value="">No Team (Admin Only)</option>
+                            <label for="project_ids" class="form-label">Assign to Projects</label>
+                            <select multiple class="form-select" id="project_ids" name="project_ids">
                                 {% for project in projects %}
-                                    <optgroup label="{{ project.name }}">
-                                        {% for team in project.teams %}
-                                            <option value="{{ team.id }}" {% if user.team_id == team.id %}selected{% endif %}>{{ team.name }}</option>
-                                        {% endfor %}
-                                    </optgroup>
+                                    <option value="{{ project.id }}" {% if project.id in user.projects|map(attribute='id')|list %}selected{% endif %}>{{ project.name }}</option>
                                 {% endfor %}
                             </select>
                         </div>

--- a/dataqe_app/templates/user_new.html
+++ b/dataqe_app/templates/user_new.html
@@ -8,8 +8,8 @@
         <div class="col-12">
             <nav aria-label="breadcrumb">
                 <ol class="breadcrumb">
-                    <li class="breadcrumb-item"><a href="{{ url_for('dashboard') }}">Dashboard</a></li>
-                    <li class="breadcrumb-item"><a href="{{ url_for('users') }}">Users</a></li>
+                    <li class="breadcrumb-item"><a href="{{ url_for('main.dashboard') }}">Dashboard</a></li>
+                    <li class="breadcrumb-item"><a href="{{ url_for('main.users') }}">Users</a></li>
                     <li class="breadcrumb-item active">New User</li>
                 </ol>
             </nav>
@@ -36,15 +36,10 @@
                         </div>
                         
                         <div class="mb-3">
-                            <label for="team_id" class="form-label">Assign to Team</label>
-                            <select class="form-select" id="team_id" name="team_id">
-                                <option value="">No Team (Admin Only)</option>
+                            <label for="project_ids" class="form-label">Assign to Projects</label>
+                            <select multiple class="form-select" id="project_ids" name="project_ids">
                                 {% for project in projects %}
-                                    <optgroup label="{{ project.name }}">
-                                        {% for team in project.teams %}
-                                            <option value="{{ team.id }}">{{ team.name }}</option>
-                                        {% endfor %}
-                                    </optgroup>
+                                    <option value="{{ project.id }}">{{ project.name }}</option>
                                 {% endfor %}
                             </select>
                         </div>
@@ -57,7 +52,7 @@
                         </div>
                         
                         <div class="d-flex justify-content-between mt-4">
-                            <a href="{{ url_for('users') }}" class="btn btn-outline-secondary">Cancel</a>
+                            <a href="{{ url_for('main.users') }}" class="btn btn-outline-secondary">Cancel</a>
                             <button type="submit" class="btn btn-primary">Create User</button>
                         </div>
                     </form>

--- a/dataqe_app/testcases/routes.py
+++ b/dataqe_app/testcases/routes.py
@@ -1,11 +1,12 @@
-from flask import Blueprint, render_template, request, redirect, url_for, flash, jsonify
+from flask import Blueprint, render_template, request, redirect, url_for, flash, jsonify, current_app
 from flask_login import login_required, current_user
 from dataqe_app import db
-from dataqe_app.models import TestCase, ScheduledTest, TestExecution, TestMismatch, User
+from dataqe_app.models import TestCase, ScheduledTest, TestExecution, TestMismatch, User, Project
 from dataqe_app.utils.helpers import run_scheduled_test
 from datetime import datetime
 import os
 import uuid
+from werkzeug.utils import secure_filename
 from apscheduler.triggers.cron import CronTrigger
 
 
@@ -16,13 +17,13 @@ testcases_bp = Blueprint('testcases', __name__)
 def delete_testcase(testcase_id):
     test_case = TestCase.query.get_or_404(testcase_id)
 
-    if not current_user.is_admin and current_user.team_id != test_case.team_id:
+    if not current_user.is_admin and current_user not in test_case.project.users:
         flash('Access denied', 'error')
         return redirect(url_for('dashboard'))
 
-    team_id = test_case.team_id
+    project_id = test_case.project_id
     tcid = test_case.tcid
-    project = test_case.team.project
+    project = test_case.project
     project_input_folder = os.path.join(project.folder_path, 'input')
 
     # Delete source and target files if they exist
@@ -52,7 +53,7 @@ def delete_testcase(testcase_id):
     db.session.commit()
 
     flash(f'Test case {tcid} deleted successfully', 'success')
-    return redirect(url_for('dashboard') if not current_user.is_admin else url_for('team_detail', team_id=team_id))
+    return redirect(url_for('dashboard') if not current_user.is_admin else url_for('projects.project_detail', project_id=project_id))
 
 
 @testcases_bp.route('/schedule/create/<int:test_case_id>', methods=['GET', 'POST'])
@@ -60,7 +61,7 @@ def delete_testcase(testcase_id):
 def create_schedule(test_case_id):
     test_case = TestCase.query.get_or_404(test_case_id)
 
-    if not current_user.is_admin and current_user.team_id != test_case.team_id:
+    if not current_user.is_admin and current_user not in test_case.project.users:
         flash('Access denied')
         return redirect(url_for('dashboard'))
 
@@ -121,24 +122,238 @@ def debug_last_execution():
 
 
 @testcases_bp.route('/testcase/new', methods=['GET', 'POST'], endpoint='new_testcase')
+@login_required
 def new_testcase():
-    """Placeholder for creating a new test case."""
-    if request.method == 'POST':
-        # For now simply acknowledge the post and redirect back
-        flash('Test case creation not implemented', 'info')
-        team_id = request.args.get('team_id') or request.form.get('team_id')
-        if team_id:
-            return redirect(url_for('team_detail', team_id=team_id))
+    """Create a new test case."""
+    project_id = request.args.get('project_id') or request.form.get('project_id')
+    if not project_id:
+        flash('Project not specified', 'error')
         return redirect(url_for('dashboard'))
 
-    return render_template('placeholder.html', title='New Test Case')
+    project = Project.query.get_or_404(project_id)
+
+    if not current_user.is_admin and current_user not in project.users:
+        flash('Access denied', 'error')
+        return redirect(url_for('dashboard'))
+
+    connections = project.connections
+
+    if request.method == 'POST':
+        tcid = request.form.get('tcid')
+        table_name = request.form.get('table_name')
+        test_type = request.form.get('test_type')
+        tc_name = request.form.get('tc_name')
+        test_yn = 'Y' if request.form.get('test_yn') else 'N'
+        src_conn_id = request.form.get('src_connection_id') or None
+        tgt_conn_id = request.form.get('tgt_connection_id') or None
+        delimiter = request.form.get('delimiter')
+        filters = request.form.get('filters')
+        pk_columns = request.form.get('pk_columns')
+        date_fields = request.form.get('date_fields')
+        percentage_fields = request.form.get('percentage_fields')
+        threshold_percentage = request.form.get('threshold_percentage')
+        header_columns = request.form.get('header_columns')
+        skip_rows = request.form.get('skip_rows')
+        src_sheet_name = request.form.get('src_sheet_name')
+        tgt_sheet_name = request.form.get('tgt_sheet_name')
+        src_input_type = request.form.get('src_input_type')
+        tgt_input_type = request.form.get('tgt_input_type')
+        src_query = request.form.get('src_query')
+        tgt_query = request.form.get('tgt_query')
+
+        project_input_folder = os.path.join(project.folder_path, 'input')
+        os.makedirs(project_input_folder, exist_ok=True)
+
+        src_file = request.files.get('src_file')
+        tgt_file = request.files.get('tgt_file')
+        src_data_file = None
+        tgt_data_file = None
+        if src_input_type == 'query' and src_query:
+            filename = f"{uuid.uuid4().hex}.sql"
+            with open(os.path.join(project_input_folder, filename), 'w') as f:
+                f.write(src_query)
+            src_data_file = filename
+        elif src_file and src_file.filename:
+            filename = f"{uuid.uuid4().hex}_{secure_filename(src_file.filename)}"
+            src_file.save(os.path.join(project_input_folder, filename))
+            src_data_file = filename
+
+        if tgt_input_type == 'query' and tgt_query:
+            filename = f"{uuid.uuid4().hex}.sql"
+            with open(os.path.join(project_input_folder, filename), 'w') as f:
+                f.write(tgt_query)
+            tgt_data_file = filename
+        elif tgt_file and tgt_file.filename:
+            filename = f"{uuid.uuid4().hex}_{secure_filename(tgt_file.filename)}"
+            tgt_file.save(os.path.join(project_input_folder, filename))
+            tgt_data_file = filename
+
+        test_case = TestCase(
+            tcid=tcid,
+            tc_name=tc_name,
+            table_name=table_name,
+            test_type=test_type,
+            test_yn=test_yn,
+            src_data_file=src_data_file,
+            tgt_data_file=tgt_data_file,
+            src_connection_id=src_conn_id,
+            tgt_connection_id=tgt_conn_id,
+            filters=filters,
+            delimiter=delimiter,
+            pk_columns=pk_columns,
+            date_fields=date_fields,
+            percentage_fields=percentage_fields,
+            threshold_percentage=threshold_percentage,
+            header_columns=header_columns,
+            skip_rows=skip_rows,
+            src_sheet_name=src_sheet_name,
+            tgt_sheet_name=tgt_sheet_name,
+            project_id=project.id,
+            creator_id=current_user.id,
+        )
+        db.session.add(test_case)
+        db.session.commit()
+
+        flash('Test case created successfully', 'success')
+        return redirect(url_for('projects.project_detail', project_id=project.id))
+    return render_template('testcase_new.html', project=project, connections=connections)
 
 
 @testcases_bp.route('/testcase/<int:testcase_id>/edit', methods=['GET', 'POST'], endpoint='edit_testcase')
+@login_required
 def edit_testcase(testcase_id):
-    """Placeholder for editing a test case."""
-    if request.method == 'POST':
-        flash('Editing test cases is not implemented', 'info')
-        return redirect(url_for('testcase_detail', testcase_id=testcase_id))
+    """Edit an existing test case."""
+    test_case = TestCase.query.get_or_404(testcase_id)
 
-    return render_template('placeholder.html', title='Edit Test Case')
+    if not current_user.is_admin and current_user not in test_case.project.users:
+        flash('Access denied', 'error')
+        return redirect(url_for('dashboard'))
+
+    project = test_case.project
+    connections = project.connections
+
+    if request.method == 'POST':
+        test_case.tcid = request.form.get('tcid')
+        test_case.table_name = request.form.get('table_name')
+        test_case.test_type = request.form.get('test_type')
+        test_case.tc_name = request.form.get('tc_name')
+        test_case.test_yn = 'Y' if request.form.get('test_yn') else 'N'
+        test_case.src_connection_id = request.form.get('src_connection_id') or None
+        test_case.tgt_connection_id = request.form.get('tgt_connection_id') or None
+        test_case.delimiter = request.form.get('delimiter')
+        test_case.filters = request.form.get('filters')
+        test_case.pk_columns = request.form.get('pk_columns')
+        test_case.date_fields = request.form.get('date_fields')
+        test_case.percentage_fields = request.form.get('percentage_fields')
+        test_case.threshold_percentage = request.form.get('threshold_percentage')
+        test_case.header_columns = request.form.get('header_columns')
+        test_case.skip_rows = request.form.get('skip_rows')
+        test_case.src_sheet_name = request.form.get('src_sheet_name')
+        test_case.tgt_sheet_name = request.form.get('tgt_sheet_name')
+        src_input_type = request.form.get('src_input_type')
+        tgt_input_type = request.form.get('tgt_input_type')
+        src_query = request.form.get('src_query')
+        tgt_query = request.form.get('tgt_query')
+
+        project_input_folder = os.path.join(project.folder_path, 'input')
+        os.makedirs(project_input_folder, exist_ok=True)
+
+        src_file = request.files.get('src_file')
+        if src_input_type == 'query' and src_query:
+            if test_case.src_data_file:
+                old_path = os.path.join(project_input_folder, test_case.src_data_file)
+                if os.path.exists(old_path):
+                    os.remove(old_path)
+            filename = f"{uuid.uuid4().hex}.sql"
+            with open(os.path.join(project_input_folder, filename), 'w') as f:
+                f.write(src_query)
+            test_case.src_data_file = filename
+        elif src_file and src_file.filename:
+            if test_case.src_data_file:
+                old_path = os.path.join(project_input_folder, test_case.src_data_file)
+                if os.path.exists(old_path):
+                    os.remove(old_path)
+            filename = f"{uuid.uuid4().hex}_{secure_filename(src_file.filename)}"
+            src_file.save(os.path.join(project_input_folder, filename))
+            test_case.src_data_file = filename
+
+        tgt_file = request.files.get('tgt_file')
+        if tgt_input_type == 'query' and tgt_query:
+            if test_case.tgt_data_file:
+                old_path = os.path.join(project_input_folder, test_case.tgt_data_file)
+                if os.path.exists(old_path):
+                    os.remove(old_path)
+            filename = f"{uuid.uuid4().hex}.sql"
+            with open(os.path.join(project_input_folder, filename), 'w') as f:
+                f.write(tgt_query)
+            test_case.tgt_data_file = filename
+        elif tgt_file and tgt_file.filename:
+            if test_case.tgt_data_file:
+                old_path = os.path.join(project_input_folder, test_case.tgt_data_file)
+                if os.path.exists(old_path):
+                    os.remove(old_path)
+            filename = f"{uuid.uuid4().hex}_{secure_filename(tgt_file.filename)}"
+            tgt_file.save(os.path.join(project_input_folder, filename))
+            test_case.tgt_data_file = filename
+
+        db.session.commit()
+
+        flash('Test case updated successfully', 'success')
+        return redirect(url_for('testcase_detail', testcase_id=test_case.id))
+
+    src_sql = None
+    tgt_sql = None
+    project_input_folder = os.path.join(project.folder_path, 'input')
+    if test_case.src_data_file:
+        src_path = os.path.join(project_input_folder, test_case.src_data_file)
+        if os.path.exists(src_path):
+            with open(src_path) as f:
+                src_sql = f.read()
+    if test_case.tgt_data_file:
+        tgt_path = os.path.join(project_input_folder, test_case.tgt_data_file)
+        if os.path.exists(tgt_path):
+            with open(tgt_path) as f:
+                tgt_sql = f.read()
+
+    return render_template('testcase_edit.html', project=project, test_case=test_case, connections=connections, src_sql=src_sql, tgt_sql=tgt_sql)
+
+@testcases_bp.route('/testcase/<int:testcase_id>', methods=['GET'])
+@login_required
+def testcase_detail(testcase_id):
+    """Display detailed information about a test case."""
+    test_case = TestCase.query.get_or_404(testcase_id)
+
+    if not current_user.is_admin and current_user not in test_case.project.users:
+        flash('Access denied', 'error')
+        return redirect(url_for('dashboard'))
+
+    project_input_folder = os.path.join(
+        test_case.project.folder_path, 'input'
+    )
+    src_sql = None
+    tgt_sql = None
+    if test_case.src_data_file:
+        src_path = os.path.join(project_input_folder, test_case.src_data_file)
+        if os.path.exists(src_path):
+            with open(src_path) as f:
+                src_sql = f.read()
+    if test_case.tgt_data_file:
+        tgt_path = os.path.join(project_input_folder, test_case.tgt_data_file)
+        if os.path.exists(tgt_path):
+            with open(tgt_path) as f:
+                tgt_sql = f.read()
+
+    sorted_executions = sorted(
+        test_case.executions,
+        key=lambda e: e.execution_time or datetime.min,
+        reverse=True
+    )
+
+    return render_template(
+        'testcase_detail.html',
+        test_case=test_case,
+        src_sql=src_sql,
+        tgt_sql=tgt_sql,
+        sorted_executions=sorted_executions[:10]
+    )
+

--- a/tests/test_project_detail.py
+++ b/tests/test_project_detail.py
@@ -37,7 +37,7 @@ from dataqe_app import create_app, db, login_manager
 def load_user(user_id):
     return None
 
-from dataqe_app.models import Project, Team
+from dataqe_app.models import Project, User
 
 
 
@@ -45,10 +45,6 @@ def test_project_detail_page():
     app = create_app()
 
 
-
-    @app.route('/teams/new/<int:project_id>')
-    def new_team(project_id):
-        return 'new team'
 
     @app.route('/connections/new/<int:project_id>')
     def new_connection(project_id):
@@ -70,21 +66,23 @@ def test_project_detail_page():
 
 
 
-def test_new_team_route():
+def test_add_member_route():
     app = create_app()
     with app.app_context():
         db.create_all()
         project = Project(name='Team Project')
-        db.session.add(project)
+        user = User(username='u', email='u@example.com')
+        user.set_password('pwd')
+        db.session.add_all([project, user])
         db.session.commit()
         pid = project.id
+        uid = user.id
 
     with app.test_client() as client:
-        resp = client.get(f'/teams/new/{pid}')
+        resp = client.post(f'/projects/{pid}/add_member', data={'user_id': uid}, follow_redirects=True)
         assert resp.status_code == 200
-        resp = client.post(f'/teams/new/{pid}', data={'name': 'Alpha'}, follow_redirects=True)
-        assert resp.status_code == 200
-        assert b'Alpha' in resp.data
+        with app.app_context():
+            assert user in Project.query.get(pid).users
 
 
 def test_new_connection_route():

--- a/tests/test_team_detail.py
+++ b/tests/test_team_detail.py
@@ -34,12 +34,16 @@ from dataqe_app import create_app, db, login_manager
 
 @login_manager.user_loader
 def load_user(user_id):
-    return None
+    return User.query.get(int(user_id))
 
-from dataqe_app.models import Project, Team, User
+def login(client, user_id):
+    with client.session_transaction() as sess:
+        sess['_user_id'] = str(user_id)
+
+from dataqe_app.models import Project, User
 
 
-def test_team_detail_page():
+def test_project_detail_page_shows_members():
     app = create_app()
 
     @app.route('/testcase/new', endpoint='new_testcase')
@@ -50,22 +54,58 @@ def test_team_detail_page():
         db.drop_all()
         db.create_all()
         project = Project(name='Demo')
-        team = Team(name='Alpha')
-        db.session.add_all([project, team])
-        db.session.commit()
-        project.team_id = team.id
         user = User(username='u1', email='u1@example.com')
         user.set_password('pass')
-        user.team_id = team.id
-        db.session.add(user)
+        db.session.add_all([project, user])
         db.session.commit()
-        tid = team.id
+        project.users.append(user)
+        db.session.commit()
+        pid = project.id
 
     with app.test_client() as client:
-        resp = client.get(f'/teams/{tid}')
+        resp = client.get(f'/projects/{pid}')
         assert resp.status_code == 200
-        assert b'Alpha' in resp.data
         assert b'u1@example.com' in resp.data
+
+
+def test_available_users_listed():
+    app = create_app()
+
+    @app.route('/testcase/new', endpoint='new_testcase')
+    def new_testcase():
+        return 'new'
+
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        project = Project(name='Demo')
+        db.session.add(project)
+        admin = User(username='admin', email='a@example.com', is_admin=True)
+        admin.set_password('pwd')
+        db.session.add(admin)
+        db.session.commit()
+        u1 = User(username='m1', email='m1@example.com')
+        u1.set_password('pwd')
+        u2 = User(username='m2', email='m2@example.com')
+        u2.set_password('pwd')
+        u3 = User(username='m3', email='m3@example.com')
+        u3.set_password('pwd')
+        db.session.add_all([u1, u2, u3])
+        db.session.commit()
+        project.users.append(u1)
+        db.session.commit()
+        pid = project.id
+        admin_id = admin.id
+
+    with app.test_client() as client:
+        login(client, admin_id)
+        resp = client.get(f'/projects/{pid}')
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        options = "".join(line.strip() for line in html.splitlines() if "<option" in line)
+        assert "m2@example.com" in options
+        assert "m3@example.com" in options
+        assert "m1@example.com" not in options
 
 
 def test_add_member_route():
@@ -78,19 +118,19 @@ def test_add_member_route():
     with app.app_context():
         db.drop_all()
         db.create_all()
-        team = Team(name='Beta')
+        project = Project(name='BetaProj')
         user = User(username='u2', email='u2@example.com')
         user.set_password('pwd')
-        db.session.add_all([team, user])
+        db.session.add_all([project, user])
         db.session.commit()
-        tid = team.id
+        pid = project.id
         uid = user.id
 
     with app.test_client() as client:
-        resp = client.post(f'/teams/{tid}/add_member', data={'user_id': uid}, follow_redirects=True)
+        resp = client.post(f'/projects/{pid}/add_member', data={'user_id': uid}, follow_redirects=True)
         assert resp.status_code == 200
         with app.app_context():
-            assert User.query.get(uid).team_id == tid
+            assert user in Project.query.get(pid).users
 
 
 def test_remove_member_route():
@@ -102,21 +142,21 @@ def test_remove_member_route():
 
     with app.app_context():
         db.create_all()
-        team = Team(name='Gamma')
+        project = Project(name='GammaProj')
         user = User(username='u3', email='u3@example.com')
         user.set_password('pwd3')
-        db.session.add_all([team, user])
+        project.users.append(user)
+        db.session.add(project)
+        db.session.add(user)
         db.session.commit()
-        user.team_id = team.id
-        db.session.commit()
-        tid = team.id
+        pid = project.id
         uid = user.id
 
     with app.test_client() as client:
-        resp = client.post(f'/teams/{tid}/remove_member/{uid}', follow_redirects=True)
+        resp = client.post(f'/projects/{pid}/remove_member/{uid}', follow_redirects=True)
         assert resp.status_code == 200
         with app.app_context():
-            assert User.query.get(uid).team_id is None
+            assert user not in Project.query.get(pid).users
 
 
 def test_edit_user_route():
@@ -138,7 +178,7 @@ def test_edit_user_route():
     with app.test_client() as client:
         resp = client.post(
             f'/users/{uid}/edit',
-            data={'username': 'new', 'email': 'new@example.com', 'password': 'newpwd', 'team_id': '', 'is_admin': ''},
+            data={'username': 'new', 'email': 'new@example.com', 'password': 'newpwd', 'project_ids': '', 'is_admin': ''},
             follow_redirects=True,
         )
         assert resp.status_code == 200

--- a/tests/test_testcase_routes.py
+++ b/tests/test_testcase_routes.py
@@ -1,0 +1,194 @@
+import sys
+import types
+import os
+from flask import Blueprint
+
+# Stub auth blueprint
+auth_module = types.ModuleType('dataqe_app.auth.routes')
+auth_bp = Blueprint('auth', __name__)
+@auth_bp.route('/login')
+def login():
+    return 'login'
+@auth_bp.route('/logout')
+def logout():
+    return 'logout'
+auth_module.auth_bp = auth_bp
+sys.modules.setdefault('dataqe_app.auth', types.ModuleType('dataqe_app.auth'))
+sys.modules['dataqe_app.auth.routes'] = auth_module
+
+# Stub DataQEBridge
+bridge_module = types.ModuleType('dataqe_app.bridge.dataqe_bridge')
+class DataQEBridge:
+    def __init__(self, app=None):
+        self.app = app
+    def init_app(self, app):
+        self.app = app
+    def execute_test_case(self, *a, **kw):
+        return {"status": "SUCCESS"}
+bridge_module.DataQEBridge = DataQEBridge
+sys.modules.setdefault('dataqe_app.bridge', types.ModuleType('dataqe_app.bridge'))
+sys.modules['dataqe_app.bridge.dataqe_bridge'] = bridge_module
+
+import apscheduler.schedulers.background
+apscheduler.schedulers.background.BackgroundScheduler.start = lambda self, *a, **k: None
+
+from dataqe_app import create_app, db, login_manager
+from dataqe_app.models import Project, User, Connection, TestCase as TestCaseModel
+
+@login_manager.user_loader
+def load_user(user_id):
+    return User.query.get(int(user_id))
+
+def login(client, user_id):
+    with client.session_transaction() as sess:
+        sess['_user_id'] = str(user_id)
+
+
+def test_new_testcase_route(tmp_path):
+    app = create_app()
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        project_folder = tmp_path / "proj"
+        project_folder.mkdir(parents=True)
+        (project_folder / "input").mkdir()
+        project = Project(name='Demo', folder_path=str(project_folder))
+        db.session.add(project)
+        db.session.commit()
+        conn1 = Connection(name='SrcConn', project_id=project.id)
+        conn2 = Connection(name='TgtConn', project_id=project.id)
+        db.session.add_all([conn1, conn2])
+        user = User(username='u', email='u@example.com')
+        user.set_password('pwd')
+        project.users.append(user)
+        db.session.add(user)
+        db.session.commit()
+        uid = user.id
+        pid = project.id
+
+    with app.test_client() as client:
+        login(client, uid)
+        # verify dropdown shows connections
+        get_resp = client.get(f'/testcase/new?project_id={pid}')
+        assert get_resp.status_code == 200
+        html = get_resp.data.decode()
+        assert 'SrcConn' in html and 'TgtConn' in html
+
+        resp = client.post(
+            f'/testcase/new?project_id={pid}',
+            data={
+                'tcid': 'TC1',
+                'tc_name': 'Test',
+                'table_name': 'tbl',
+                'test_type': 'CCD_Validation',
+                'delimiter': ',',
+                'src_input_type': 'query',
+                'src_query': 'select 1',
+                'tgt_input_type': 'query',
+                'tgt_query': 'select 2'
+            },
+            follow_redirects=True
+        )
+        assert resp.status_code == 200
+        with app.app_context():
+            tc = TestCaseModel.query.filter_by(tcid='TC1').first()
+            assert tc is not None
+            assert tc.project_id == pid
+            src_path = project_folder / 'input' / tc.src_data_file
+            tgt_path = project_folder / 'input' / tc.tgt_data_file
+            assert src_path.exists() and tgt_path.exists()
+            assert src_path.read_text() == 'select 1'
+            assert tgt_path.read_text() == 'select 2'
+
+
+def test_edit_testcase_route(tmp_path):
+    app = create_app()
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        proj_folder = tmp_path / "proj2"
+        proj_folder.mkdir(parents=True)
+        (proj_folder / "input").mkdir()
+        project = Project(name='Demo', folder_path=str(proj_folder))
+        project = Project(name='Demo', folder_path=str(proj_folder))
+        db.session.add(project)
+        db.session.commit()
+        user = User(username='u', email='u@example.com')
+        user.set_password('pwd')
+        project.users.append(user)
+        db.session.add(user)
+        db.session.commit()
+        # existing file for query
+        old_query = proj_folder / 'input' / 'old.sql'
+        old_query.write_text('old src')
+        tc = TestCaseModel(
+            tcid='TC1',
+            tc_name='Old',
+            table_name='tbl',
+            test_type='CCD_Validation',
+            project_id=project.id,
+            src_data_file='old.sql'
+        )
+        db.session.add(tc)
+        db.session.commit()
+        uid = user.id
+        tcid = tc.id
+
+    with app.test_client() as client:
+        login(client, uid)
+        resp = client.post(
+            f'/testcase/{tcid}/edit',
+            data={
+                'tcid': 'TC1',
+                'tc_name': 'NewName',
+                'table_name': 'tbl2',
+                'test_type': 'CCD_Validation',
+                'src_input_type': 'query',
+                'src_query': 'new src',
+                'tgt_input_type': 'query',
+                'tgt_query': 'new tgt'
+            },
+            follow_redirects=True
+        )
+        assert resp.status_code == 200
+        with app.app_context():
+            updated = TestCaseModel.query.get(tcid)
+            assert updated.tc_name == 'NewName'
+            assert updated.table_name == 'tbl2'
+            src_path = proj_folder / 'input' / updated.src_data_file
+            tgt_path = proj_folder / 'input' / updated.tgt_data_file
+            assert src_path.exists() and tgt_path.exists()
+            assert src_path.read_text() == 'new src'
+            assert tgt_path.read_text() == 'new tgt'
+            assert not old_query.exists()
+
+
+def test_testcase_detail_route(tmp_path):
+    app = create_app()
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        folder = tmp_path / "proj3"
+        folder.mkdir(parents=True)
+        (folder / "input").mkdir()
+        project = Project(name='Demo', folder_path=str(folder))
+        db.session.add(project)
+        db.session.commit()
+        user = User(username='u', email='u@example.com')
+        user.set_password('pwd')
+        project.users.append(user)
+        db.session.add(user)
+        tc = TestCaseModel(tcid='TC2', table_name='tbl', test_type='CCD_Validation', project_id=project.id)
+        db.session.add(tc)
+        db.session.commit()
+        uid = user.id
+        tcid = tc.id
+
+    with app.test_client() as client:
+        login(client, uid)
+        resp = client.get(f'/testcase/{tcid}')
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert 'Test Case Details' in html
+        assert 'TC2' in html
+


### PR DESCRIPTION
## Summary
- drop Team model usage and store project-user memberships instead
- allow admins to add or remove project members
- update test case routes and templates to use project IDs
- adapt user forms and project page to list members
- rewrite tests for new project membership logic

## Testing
- `pip install -r requirements.txt`
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_6845ec81f6208323b4efe79809dd5f93