### PR TITLE
Add SQL form handling with persistent query files

### DIFF
--- a/dataqe_app/testcases/forms.py
+++ b/dataqe_app/testcases/forms.py
@@ -1,0 +1,63 @@
+from flask_wtf import FlaskForm
+from wtforms import StringField, TextAreaField, SelectField, BooleanField, FileField
+from wtforms.validators import DataRequired, Optional
+
+
+class TestCaseForm(FlaskForm):
+    """Form for creating and editing test cases."""
+
+    tcid = StringField('TCID', validators=[DataRequired()])
+    tc_name = StringField('Test Case Name', validators=[DataRequired()])
+    table_name = StringField('Table Name', validators=[DataRequired()])
+    test_type = StringField('Test Type', validators=[DataRequired()])
+    test_yn = BooleanField('Test?')
+
+    src_connection_id = StringField('Source Connection', validators=[Optional()])
+    tgt_connection_id = StringField('Target Connection', validators=[Optional()])
+    delimiter = StringField('Delimiter', validators=[Optional()])
+    filters = StringField('Filters', validators=[Optional()])
+    pk_columns = StringField('PK Columns', validators=[DataRequired()])
+    date_fields = StringField('Date Fields', validators=[Optional()])
+    percentage_fields = StringField('Percentage Fields', validators=[Optional()])
+    threshold_percentage = StringField('Threshold Percentage', validators=[Optional()])
+    header_columns = StringField('Header Columns', validators=[Optional()])
+    skip_rows = StringField('Skip Rows', validators=[Optional()])
+    src_sheet_name = StringField('Source Sheet Name', validators=[Optional()])
+    tgt_sheet_name = StringField('Target Sheet Name', validators=[Optional()])
+
+    src_input_type = SelectField(
+        'Source Input Type', choices=[('query', 'Query'), ('file', 'File')], validators=[DataRequired()]
+    )
+    tgt_input_type = SelectField(
+        'Target Input Type', choices=[('query', 'Query'), ('file', 'File')], validators=[DataRequired()]
+    )
+    src_query = TextAreaField('Source Query', validators=[Optional()])
+    tgt_query = TextAreaField('Target Query', validators=[Optional()])
+    src_file = FileField('Source File', validators=[Optional()])
+    tgt_file = FileField('Target File', validators=[Optional()])
+
+    class Meta:
+        csrf = False
+
+    def validate(self, extra_validators=None):
+        if not super().validate(extra_validators=extra_validators):
+            return False
+
+        if self.src_input_type.data == 'query' and not self.src_query.data:
+            self.src_query.errors.append('Source query is required.')
+            return False
+        if self.src_input_type.data == 'file' and (
+            not self.src_file.data or not getattr(self.src_file.data, 'filename', '')
+        ):
+            self.src_file.errors.append('Source file is required.')
+            return False
+        if self.tgt_input_type.data == 'query' and not self.tgt_query.data:
+            self.tgt_query.errors.append('Target query is required.')
+            return False
+        if self.tgt_input_type.data == 'file' and (
+            not self.tgt_file.data or not getattr(self.tgt_file.data, 'filename', '')
+        ):
+            self.tgt_file.errors.append('Target file is required.')
+            return False
+
+        return True

--- a/dataqe_app/testcases/routes.py
+++ b/dataqe_app/testcases/routes.py
@@ -1,16 +1,25 @@
-from flask import Blueprint, render_template, request, redirect, url_for, flash, jsonify, current_app
+from flask import Blueprint, render_template, request, redirect, url_for, flash, jsonify
 from flask_login import login_required, current_user
 from dataqe_app import db
-from dataqe_app.models import TestCase, ScheduledTest, TestExecution, TestMismatch, User, Project
+from dataqe_app.models import (
+    TestCase,
+    ScheduledTest,
+    TestExecution,
+    TestMismatch,
+    User,
+    Project,
+)
 from dataqe_app.utils.helpers import run_scheduled_test
 from datetime import datetime
 import os
 import uuid
 from werkzeug.utils import secure_filename
 from apscheduler.triggers.cron import CronTrigger
+from dataqe_app.testcases.forms import TestCaseForm
 
 
 testcases_bp = Blueprint('testcases', __name__)
+
 
 @testcases_bp.route('/testcase/<int:testcase_id>/delete', methods=['POST'])
 @login_required
@@ -21,12 +30,9 @@ def delete_testcase(testcase_id):
         flash('Access denied', 'error')
         return redirect(url_for('dashboard'))
 
-    project_id = test_case.project_id
-    tcid = test_case.tcid
     project = test_case.project
     project_input_folder = os.path.join(project.folder_path, 'input')
 
-    # Delete source and target files if they exist
     for data_file in [test_case.src_data_file, test_case.tgt_data_file]:
         if data_file:
             file_path = os.path.join(project_input_folder, data_file)
@@ -36,10 +42,8 @@ def delete_testcase(testcase_id):
                 except Exception as e:
                     print(f"Error deleting file {file_path}: {e}")
 
-    # Delete schedules
     ScheduledTest.query.filter_by(test_case_id=testcase_id).delete()
 
-    # Delete executions and mismatches
     for execution in TestExecution.query.filter_by(test_case_id=testcase_id).all():
         TestMismatch.query.filter_by(execution_id=execution.id).delete()
         if execution.log_file and os.path.exists(execution.log_file):
@@ -47,13 +51,13 @@ def delete_testcase(testcase_id):
                 os.remove(execution.log_file)
             except Exception as e:
                 print(f"Error deleting log file: {e}")
-
     TestExecution.query.filter_by(test_case_id=testcase_id).delete()
+
     db.session.delete(test_case)
     db.session.commit()
 
-    flash(f'Test case {tcid} deleted successfully', 'success')
-    return redirect(url_for('dashboard') if not current_user.is_admin else url_for('projects.project_detail', project_id=project_id))
+    flash(f'Test case {test_case.tcid} deleted successfully', 'success')
+    return redirect(url_for('dashboard') if not current_user.is_admin else url_for('projects.project_detail', project_id=project.id))
 
 
 @testcases_bp.route('/schedule/create/<int:test_case_id>', methods=['GET', 'POST'])
@@ -137,77 +141,56 @@ def new_testcase():
         return redirect(url_for('dashboard'))
 
     connections = project.connections
+    form = TestCaseForm()
 
-    if request.method == 'POST':
-        tcid = request.form.get('tcid')
-        table_name = request.form.get('table_name')
-        test_type = request.form.get('test_type')
-        tc_name = request.form.get('tc_name')
-        test_yn = 'Y' if request.form.get('test_yn') else 'N'
-        src_conn_id = request.form.get('src_connection_id') or None
-        tgt_conn_id = request.form.get('tgt_connection_id') or None
-        delimiter = request.form.get('delimiter')
-        filters = request.form.get('filters')
-        pk_columns = request.form.get('pk_columns')
-        date_fields = request.form.get('date_fields')
-        percentage_fields = request.form.get('percentage_fields')
-        threshold_percentage = request.form.get('threshold_percentage')
-        header_columns = request.form.get('header_columns')
-        skip_rows = request.form.get('skip_rows')
-        src_sheet_name = request.form.get('src_sheet_name')
-        tgt_sheet_name = request.form.get('tgt_sheet_name')
-        src_input_type = request.form.get('src_input_type')
-        tgt_input_type = request.form.get('tgt_input_type')
-        src_query = request.form.get('src_query')
-        tgt_query = request.form.get('tgt_query')
-
+    if form.validate_on_submit():
         project_input_folder = os.path.join(project.folder_path, 'input')
         os.makedirs(project_input_folder, exist_ok=True)
 
-        src_file = request.files.get('src_file')
-        tgt_file = request.files.get('tgt_file')
+        tcid = form.tcid.data
+
         src_data_file = None
+        if form.src_input_type.data == 'query':
+            src_filename = f"{tcid}_src.sql"
+            with open(os.path.join(project_input_folder, src_filename), 'w') as f:
+                f.write(form.src_query.data)
+            src_data_file = src_filename
+        elif form.src_file.data and form.src_file.data.filename:
+            filename = f"{uuid.uuid4().hex}_{secure_filename(form.src_file.data.filename)}"
+            form.src_file.data.save(os.path.join(project_input_folder, filename))
+            src_data_file = filename
+
         tgt_data_file = None
-        if src_input_type == 'query' and src_query:
-            filename = f"{uuid.uuid4().hex}.sql"
-            with open(os.path.join(project_input_folder, filename), 'w') as f:
-                f.write(src_query)
-            src_data_file = filename
-        elif src_file and src_file.filename:
-            filename = f"{uuid.uuid4().hex}_{secure_filename(src_file.filename)}"
-            src_file.save(os.path.join(project_input_folder, filename))
-            src_data_file = filename
-
-        if tgt_input_type == 'query' and tgt_query:
-            filename = f"{uuid.uuid4().hex}.sql"
-            with open(os.path.join(project_input_folder, filename), 'w') as f:
-                f.write(tgt_query)
-            tgt_data_file = filename
-        elif tgt_file and tgt_file.filename:
-            filename = f"{uuid.uuid4().hex}_{secure_filename(tgt_file.filename)}"
-            tgt_file.save(os.path.join(project_input_folder, filename))
+        if form.tgt_input_type.data == 'query':
+            tgt_filename = f"{tcid}_tgt.sql"
+            with open(os.path.join(project_input_folder, tgt_filename), 'w') as f:
+                f.write(form.tgt_query.data)
+            tgt_data_file = tgt_filename
+        elif form.tgt_file.data and form.tgt_file.data.filename:
+            filename = f"{uuid.uuid4().hex}_{secure_filename(form.tgt_file.data.filename)}"
+            form.tgt_file.data.save(os.path.join(project_input_folder, filename))
             tgt_data_file = filename
 
         test_case = TestCase(
             tcid=tcid,
-            tc_name=tc_name,
-            table_name=table_name,
-            test_type=test_type,
-            test_yn=test_yn,
+            tc_name=form.tc_name.data,
+            table_name=form.table_name.data,
+            test_type=form.test_type.data,
+            test_yn='Y' if form.test_yn.data else 'N',
             src_data_file=src_data_file,
             tgt_data_file=tgt_data_file,
-            src_connection_id=src_conn_id,
-            tgt_connection_id=tgt_conn_id,
-            filters=filters,
-            delimiter=delimiter,
-            pk_columns=pk_columns,
-            date_fields=date_fields,
-            percentage_fields=percentage_fields,
-            threshold_percentage=threshold_percentage,
-            header_columns=header_columns,
-            skip_rows=skip_rows,
-            src_sheet_name=src_sheet_name,
-            tgt_sheet_name=tgt_sheet_name,
+            src_connection_id=form.src_connection_id.data or None,
+            tgt_connection_id=form.tgt_connection_id.data or None,
+            filters=form.filters.data,
+            delimiter=form.delimiter.data,
+            pk_columns=form.pk_columns.data,
+            date_fields=form.date_fields.data,
+            percentage_fields=form.percentage_fields.data,
+            threshold_percentage=form.threshold_percentage.data,
+            header_columns=form.header_columns.data,
+            skip_rows=form.skip_rows.data,
+            src_sheet_name=form.src_sheet_name.data,
+            tgt_sheet_name=form.tgt_sheet_name.data,
             project_id=project.id,
             creator_id=current_user.id,
         )
@@ -216,136 +199,9 @@ def new_testcase():
 
         flash('Test case created successfully', 'success')
         return redirect(url_for('projects.project_detail', project_id=project.id))
-    return render_template('testcase_new.html', project=project, connections=connections)
-    return redirect(url_for('dashboard'))
 
-    project = Project.query.get_or_404(project_id)
+    return render_template('testcase_new.html', project=project, connections=connections, form=form)
 
-
-    if not current_user.is_admin and current_user not in project.users:
-        flash('Access denied', 'error')
-        return redirect(url_for('dashboard'))
-
-    connections = project.connections
-
-    if request.method == 'POST':
-        tcid = request.form.get('tcid')
-        table_name = request.form.get('table_name')
-        test_type = request.form.get('test_type')
-        tc_name = request.form.get('tc_name')
-        test_yn = 'Y' if request.form.get('test_yn') else 'N'
-        src_conn_id = request.form.get('src_connection_id') or None
-        tgt_conn_id = request.form.get('tgt_connection_id') or None
-        delimiter = request.form.get('delimiter')
-        filters = request.form.get('filters')
-        pk_columns = request.form.get('pk_columns')
-        date_fields = request.form.get('date_fields')
-        percentage_fields = request.form.get('percentage_fields')
-        threshold_percentage = request.form.get('threshold_percentage')
-        header_columns = request.form.get('header_columns')
-        skip_rows = request.form.get('skip_rows')
-        src_sheet_name = request.form.get('src_sheet_name')
-        tgt_sheet_name = request.form.get('tgt_sheet_name')
-        src_input_type = request.form.get('src_input_type')
-        tgt_input_type = request.form.get('tgt_input_type')
-        src_query = request.form.get('src_query')
-        tgt_query = request.form.get('tgt_query')
-
-        project_input_folder = os.path.join(project.folder_path, 'input')
-        os.makedirs(project_input_folder, exist_ok=True)
-
-        src_file = request.files.get('src_file')
-        tgt_file = request.files.get('tgt_file')
-        src_data_file = None
-        tgt_data_file = None
-        if src_input_type == 'query' and src_query:
-            filename = f"{uuid.uuid4().hex}.sql"
-            with open(os.path.join(project_input_folder, filename), 'w') as f:
-                f.write(src_query)
-            src_data_file = filename
-        elif src_file and src_file.filename:
-            filename = f"{uuid.uuid4().hex}_{secure_filename(src_file.filename)}"
-            src_file.save(os.path.join(project_input_folder, filename))
-            src_data_file = filename
-
-        if tgt_input_type == 'query' and tgt_query:
-            filename = f"{uuid.uuid4().hex}.sql"
-            with open(os.path.join(project_input_folder, filename), 'w') as f:
-                f.write(tgt_query)
-            tgt_data_file = filename
-        elif tgt_file and tgt_file.filename:
-            filename = f"{uuid.uuid4().hex}_{secure_filename(tgt_file.filename)}"
-            tgt_file.save(os.path.join(project_input_folder, filename))
-            tgt_data_file = filename
-
-        test_case = TestCase(
-            tcid=tcid,
-            tc_name=tc_name,
-            table_name=table_name,
-            test_type=test_type,
-            test_yn=test_yn,
-            src_data_file=src_data_file,
-            tgt_data_file=tgt_data_file,
-            src_connection_id=src_conn_id,
-            tgt_connection_id=tgt_conn_id,
-            filters=filters,
-            delimiter=delimiter,
-            pk_columns=pk_columns,
-            date_fields=date_fields,
-            percentage_fields=percentage_fields,
-            threshold_percentage=threshold_percentage,
-            header_columns=header_columns,
-            skip_rows=skip_rows,
-            src_sheet_name=src_sheet_name,
-            tgt_sheet_name=tgt_sheet_name,
-            project_id=project.id,
-            creator_id=current_user.id,
-        )
-        db.session.add(test_case)
-        db.session.commit()
-
-        flash('Test case created successfully', 'success')
-        return redirect(url_for('projects.project_detail', project_id=project.id))
-    return render_template('testcase_new.html', project=project, connections=connections)
-
-    if src_file and src_file.filename:
-        filename = f"{uuid.uuid4().hex}_{secure_filename(src_file.filename)}"
-        src_file.save(os.path.join(project_input_folder, filename))
-        src_data_file = filename
-    if tgt_file and tgt_file.filename:
-        filename = f"{uuid.uuid4().hex}_{secure_filename(tgt_file.filename)}"
-        tgt_file.save(os.path.join(project_input_folder, filename))
-        tgt_data_file = filename
-
-        test_case = TestCase(
-            tcid=tcid,
-            tc_name=tc_name,
-            table_name=table_name,
-            test_type=test_type,
-            test_yn=test_yn,
-            src_data_file=src_data_file,
-            tgt_data_file=tgt_data_file,
-            src_connection_id=src_conn_id,
-            tgt_connection_id=tgt_conn_id,
-            filters=filters,
-            delimiter=delimiter,
-            pk_columns=pk_columns,
-            date_fields=date_fields,
-            percentage_fields=percentage_fields,
-            threshold_percentage=threshold_percentage,
-            header_columns=header_columns,
-            skip_rows=skip_rows,
-            src_sheet_name=src_sheet_name,
-            tgt_sheet_name=tgt_sheet_name,
-            project_id=project.id,
-            creator_id=current_user.id,
-        )
-        db.session.add(test_case)
-        db.session.commit()
-
-        flash('Test case created successfully', 'success')
-        return redirect(url_for('projects.project_detail', project_id=project.id))
-    return render_template('testcase_new.html', project=project, connections=connections)
 
 @testcases_bp.route('/testcase/<int:testcase_id>/edit', methods=['GET', 'POST'], endpoint='edit_testcase')
 @login_required
@@ -359,109 +215,87 @@ def edit_testcase(testcase_id):
 
     project = test_case.project
     connections = project.connections
+    project_input_folder = os.path.join(project.folder_path, 'input')
+    os.makedirs(project_input_folder, exist_ok=True)
 
-    if request.method == 'POST':
-        test_case.tcid = request.form.get('tcid')
-        test_case.table_name = request.form.get('table_name')
-        test_case.test_type = request.form.get('test_type')
-        test_case.tc_name = request.form.get('tc_name')
-        test_case.test_yn = 'Y' if request.form.get('test_yn') else 'N'
-        test_case.src_connection_id = request.form.get('src_connection_id') or None
-        test_case.tgt_connection_id = request.form.get('tgt_connection_id') or None
-        test_case.delimiter = request.form.get('delimiter')
-        test_case.filters = request.form.get('filters')
-        test_case.pk_columns = request.form.get('pk_columns')
-        test_case.date_fields = request.form.get('date_fields')
-        test_case.percentage_fields = request.form.get('percentage_fields')
-        test_case.threshold_percentage = request.form.get('threshold_percentage')
-        test_case.header_columns = request.form.get('header_columns')
-        test_case.skip_rows = request.form.get('skip_rows')
-        test_case.src_sheet_name = request.form.get('src_sheet_name')
-        test_case.tgt_sheet_name = request.form.get('tgt_sheet_name')
-        src_input_type = request.form.get('src_input_type')
-        tgt_input_type = request.form.get('tgt_input_type')
-        src_query = request.form.get('src_query')
-        tgt_query = request.form.get('tgt_query')
+    form = TestCaseForm(obj=test_case)
 
-        project_input_folder = os.path.join(project.folder_path, 'input')
-        os.makedirs(project_input_folder, exist_ok=True)
+    if request.method == 'GET':
+        if test_case.src_data_file and test_case.src_data_file.endswith('_src.sql'):
+            src_path = os.path.join(project_input_folder, test_case.src_data_file)
+            if os.path.exists(src_path):
+                with open(src_path) as f:
+                    form.src_query.data = f.read()
+            form.src_input_type.data = 'query'
+        else:
+            form.src_input_type.data = 'file'
 
-        src_file = request.files.get('src_file')
-        if src_input_type == 'query' and src_query:
+        if test_case.tgt_data_file and test_case.tgt_data_file.endswith('_tgt.sql'):
+            tgt_path = os.path.join(project_input_folder, test_case.tgt_data_file)
+            if os.path.exists(tgt_path):
+                with open(tgt_path) as f:
+                    form.tgt_query.data = f.read()
+            form.tgt_input_type.data = 'query'
+        else:
+            form.tgt_input_type.data = 'file'
+
+    if form.validate_on_submit():
+        test_case.tcid = form.tcid.data
+        test_case.table_name = form.table_name.data
+        test_case.test_type = form.test_type.data
+        test_case.tc_name = form.tc_name.data
+        test_case.test_yn = 'Y' if form.test_yn.data else 'N'
+        test_case.src_connection_id = form.src_connection_id.data or None
+        test_case.tgt_connection_id = form.tgt_connection_id.data or None
+        test_case.delimiter = form.delimiter.data
+        test_case.filters = form.filters.data
+        test_case.pk_columns = form.pk_columns.data
+        test_case.date_fields = form.date_fields.data
+        test_case.percentage_fields = form.percentage_fields.data
+        test_case.threshold_percentage = form.threshold_percentage.data
+        test_case.header_columns = form.header_columns.data
+        test_case.skip_rows = form.skip_rows.data
+        test_case.src_sheet_name = form.src_sheet_name.data
+        test_case.tgt_sheet_name = form.tgt_sheet_name.data
+
+        tcid = form.tcid.data
+
+        if form.src_input_type.data == 'query':
+            src_filename = f"{tcid}_src.sql"
+            with open(os.path.join(project_input_folder, src_filename), 'w') as f:
+                f.write(form.src_query.data)
+            test_case.src_data_file = src_filename
+        elif form.src_file.data and form.src_file.data.filename:
             if test_case.src_data_file:
                 old_path = os.path.join(project_input_folder, test_case.src_data_file)
                 if os.path.exists(old_path):
                     os.remove(old_path)
-            filename = f"{uuid.uuid4().hex}.sql"
-            with open(os.path.join(project_input_folder, filename), 'w') as f:
-                f.write(src_query)
-            test_case.src_data_file = filename
-        elif src_file and src_file.filename:
-            if test_case.src_data_file:
-                old_path = os.path.join(project_input_folder, test_case.src_data_file)
-                if os.path.exists(old_path):
-                    os.remove(old_path)
-            filename = f"{uuid.uuid4().hex}_{secure_filename(src_file.filename)}"
-            src_file.save(os.path.join(project_input_folder, filename))
+            filename = f"{uuid.uuid4().hex}_{secure_filename(form.src_file.data.filename)}"
+            form.src_file.data.save(os.path.join(project_input_folder, filename))
             test_case.src_data_file = filename
 
-            if src_file and src_file.filename:
-                if test_case.src_data_file:
-                    old_path = os.path.join(project_input_folder, test_case.src_data_file)
-                    if os.path.exists(old_path):
-                        os.remove(old_path)
-                filename = f"{uuid.uuid4().hex}_{secure_filename(src_file.filename)}"
-                src_file.save(os.path.join(project_input_folder, filename))
-                test_case.src_data_file = filename
-        tgt_file = request.files.get('tgt_file')
-        if tgt_input_type == 'query' and tgt_query:
+        if form.tgt_input_type.data == 'query':
+            tgt_filename = f"{tcid}_tgt.sql"
+            with open(os.path.join(project_input_folder, tgt_filename), 'w') as f:
+                f.write(form.tgt_query.data)
+            test_case.tgt_data_file = tgt_filename
+        elif form.tgt_file.data and form.tgt_file.data.filename:
             if test_case.tgt_data_file:
                 old_path = os.path.join(project_input_folder, test_case.tgt_data_file)
                 if os.path.exists(old_path):
                     os.remove(old_path)
-            filename = f"{uuid.uuid4().hex}.sql"
-            with open(os.path.join(project_input_folder, filename), 'w') as f:
-                f.write(tgt_query)
+            filename = f"{uuid.uuid4().hex}_{secure_filename(form.tgt_file.data.filename)}"
+            form.tgt_file.data.save(os.path.join(project_input_folder, filename))
             test_case.tgt_data_file = filename
-        elif tgt_file and tgt_file.filename:
-            if test_case.tgt_data_file:
-                old_path = os.path.join(project_input_folder, test_case.tgt_data_file)
-                if os.path.exists(old_path):
-                    os.remove(old_path)
-            filename = f"{uuid.uuid4().hex}_{secure_filename(tgt_file.filename)}"
-            tgt_file.save(os.path.join(project_input_folder, filename))
-            test_case.tgt_data_file = filename
-
-            if tgt_file and tgt_file.filename:
-                if test_case.tgt_data_file:
-                    old_path = os.path.join(project_input_folder, test_case.tgt_data_file)
-                    if os.path.exists(old_path):
-                        os.remove(old_path)
-                filename = f"{uuid.uuid4().hex}_{secure_filename(tgt_file.filename)}"
-                tgt_file.save(os.path.join(project_input_folder, filename))
-                test_case.tgt_data_file = filename
-
 
         db.session.commit()
-
         flash('Test case updated successfully', 'success')
         return redirect(url_for('testcase_detail', testcase_id=test_case.id))
 
-    src_sql = None
-    tgt_sql = None
-    project_input_folder = os.path.join(project.folder_path, 'input')
-    if test_case.src_data_file:
-        src_path = os.path.join(project_input_folder, test_case.src_data_file)
-        if os.path.exists(src_path):
-            with open(src_path) as f:
-                src_sql = f.read()
-    if test_case.tgt_data_file:
-        tgt_path = os.path.join(project_input_folder, test_case.tgt_data_file)
-        if os.path.exists(tgt_path):
-            with open(tgt_path) as f:
-                tgt_sql = f.read()
+    src_sql = form.src_query.data if form.src_input_type.data == 'query' else None
+    tgt_sql = form.tgt_query.data if form.tgt_input_type.data == 'query' else None
+    return render_template('testcase_edit.html', project=project, test_case=test_case, connections=connections, form=form, src_sql=src_sql, tgt_sql=tgt_sql)
 
-    return render_template('testcase_edit.html', project=project, test_case=test_case, connections=connections, src_sql=src_sql, tgt_sql=tgt_sql)
 
 @testcases_bp.route('/testcase/<int:testcase_id>', methods=['GET'])
 @login_required
@@ -502,4 +336,3 @@ def testcase_detail(testcase_id):
         tgt_sql=tgt_sql,
         sorted_executions=sorted_executions[:10]
     )
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Flask==2.3.3
+Flask-WTF==1.1.1
 Flask-SQLAlchemy==3.1.1
 Flask-Login==0.6.2
 Flask-Mail==0.9.1

--- a/tests/test_testcase_routes.py
+++ b/tests/test_testcase_routes.py
@@ -6,12 +6,15 @@ from flask import Blueprint
 # Stub auth blueprint
 auth_module = types.ModuleType('dataqe_app.auth.routes')
 auth_bp = Blueprint('auth', __name__)
+
 @auth_bp.route('/login')
 def login():
     return 'login'
+
 @auth_bp.route('/logout')
 def logout():
     return 'logout'
+
 auth_module.auth_bp = auth_bp
 sys.modules.setdefault('dataqe_app.auth', types.ModuleType('dataqe_app.auth'))
 sys.modules['dataqe_app.auth.routes'] = auth_module
@@ -35,16 +38,19 @@ apscheduler.schedulers.background.BackgroundScheduler.start = lambda self, *a, *
 from dataqe_app import create_app, db, login_manager
 from dataqe_app.models import Project, User, Connection, TestCase as TestCaseModel
 
+
 @login_manager.user_loader
 def load_user(user_id):
     return User.query.get(int(user_id))
+
 
 def login(client, user_id):
     with client.session_transaction() as sess:
         sess['_user_id'] = str(user_id)
 
 
-def test_new_testcase_route(tmp_path):
+def setup_project(tmp_path):
+    """Create project, connections and user for tests."""
     app = create_app()
     with app.app_context():
         db.drop_all()
@@ -65,42 +71,48 @@ def test_new_testcase_route(tmp_path):
         db.session.commit()
         uid = user.id
         pid = project.id
+    return app, project_folder, uid, pid
 
+
+def test_new_testcase_route_saves_queries(tmp_path):
+    app, project_folder, uid, pid = setup_project(tmp_path)
     with app.test_client() as client:
         login(client, uid)
-        # verify dropdown shows connections
-        get_resp = client.get(f'/testcase/new?project_id={pid}')
-        team = Team(name='Team1')
-        db.session.add_all([project, team])
-        db.session.commit()
-        project.team_id = team.id
-
-        conn1 = Connection(name='SrcConn', project_id=project.id)
-        conn2 = Connection(name='TgtConn', project_id=project.id)
-        db.session.add_all([conn1, conn2])
-
-
-        user = User(username='u', email='u@example.com')
-        user.set_password('pwd')
-        user.team_id = team.id
-        db.session.add(user)
-        db.session.commit()
-        uid = user.id
-        tid = team.id
-
-    with app.test_client() as client:
-        login(client, uid)
-
-        # verify dropdown shows connections
-        get_resp = client.get(f'/testcase/new?team_id={tid}')
-        assert get_resp.status_code == 200
-        html = get_resp.data.decode()
-        assert 'SrcConn' in html and 'TgtConn' in html
-
         resp = client.post(
             f'/testcase/new?project_id={pid}',
             data={
                 'tcid': 'TC1',
+                'tc_name': 'Test',
+                'table_name': 'tbl',
+                'test_type': 'CCD_Validation',
+                'delimiter': ',',
+                'pk_columns': 'id',
+                'filters': '',
+                'src_input_type': 'query',
+                'src_query': 'select 1',
+                'tgt_input_type': 'query',
+                'tgt_query': 'select 2'
+            },
+            follow_redirects=True
+        )
+        assert resp.status_code == 200
+    with app.app_context():
+        tc = TestCaseModel.query.filter_by(tcid='TC1').first()
+        assert tc is not None
+        src_path = project_folder / 'input' / f'{tc.tcid}_src.sql'
+        tgt_path = project_folder / 'input' / f'{tc.tcid}_tgt.sql'
+        assert src_path.exists() and src_path.read_text() == 'select 1'
+        assert tgt_path.exists() and tgt_path.read_text() == 'select 2'
+
+
+def test_new_testcase_requires_pk(tmp_path):
+    app, project_folder, uid, pid = setup_project(tmp_path)
+    with app.test_client() as client:
+        login(client, uid)
+        resp = client.post(
+            f'/testcase/new?project_id={pid}',
+            data={
+                'tcid': 'TC2',
                 'tc_name': 'Test',
                 'table_name': 'tbl',
                 'test_type': 'CCD_Validation',
@@ -112,69 +124,39 @@ def test_new_testcase_route(tmp_path):
             },
             follow_redirects=True
         )
-
-        resp = client.post(f'/testcase/new?team_id={tid}', data={
-            'tcid': 'TC1',
-            'tc_name': 'Test',
-            'table_name': 'tbl',
-            'test_type': 'CCD_Validation',
-            'delimiter': ','
-        }, follow_redirects=True)
-
         assert resp.status_code == 200
-        with app.app_context():
-            tc = TestCaseModel.query.filter_by(tcid='TC1').first()
-            assert tc is not None
-            assert tc.project_id == pid
-            src_path = project_folder / 'input' / tc.src_data_file
-            tgt_path = project_folder / 'input' / tc.tgt_data_file
-            assert src_path.exists() and tgt_path.exists()
-            assert src_path.read_text() == 'select 1'
-            assert tgt_path.read_text() == 'select 2'
-
-
-def test_edit_testcase_route(tmp_path):
-    app = create_app()
     with app.app_context():
-        db.drop_all()
-        db.create_all()
-        proj_folder = tmp_path / "proj2"
-        proj_folder.mkdir(parents=True)
-        (proj_folder / "input").mkdir()
-        project = Project(name='Demo', folder_path=str(proj_folder))
-        project = Project(name='Demo', folder_path=str(proj_folder))
-        db.session.add(project)
-        db.session.commit()
-        user = User(username='u', email='u@example.com')
-        user.set_password('pwd')
-        project.users.append(user)
-        db.session.add(user)
-        db.session.commit()
-        # existing file for query
-        old_query = proj_folder / 'input' / 'old.sql'
-        old_query.write_text('old src')
+        assert TestCaseModel.query.filter_by(tcid='TC2').first() is None
+
+
+def test_edit_testcase_overwrites_sql(tmp_path):
+    app, project_folder, uid, pid = setup_project(tmp_path)
+    with app.app_context():
+        (project_folder / 'input' / 'TC1_src.sql').write_text('old src')
+        (project_folder / 'input' / 'TC1_tgt.sql').write_text('old tgt')
         tc = TestCaseModel(
             tcid='TC1',
             tc_name='Old',
             table_name='tbl',
             test_type='CCD_Validation',
-            project_id=project.id,
-            src_data_file='old.sql'
+            pk_columns='id',
+            project_id=pid,
+            src_data_file='TC1_src.sql',
+            tgt_data_file='TC1_tgt.sql'
         )
         db.session.add(tc)
         db.session.commit()
-        uid = user.id
         tcid = tc.id
-
     with app.test_client() as client:
         login(client, uid)
         resp = client.post(
             f'/testcase/{tcid}/edit',
             data={
                 'tcid': 'TC1',
-                'tc_name': 'NewName',
+                'tc_name': 'New',
                 'table_name': 'tbl2',
                 'test_type': 'CCD_Validation',
+                'pk_columns': 'id',
                 'src_input_type': 'query',
                 'src_query': 'new src',
                 'tgt_input_type': 'query',
@@ -182,51 +164,30 @@ def test_edit_testcase_route(tmp_path):
             },
             follow_redirects=True
         )
-        resp = client.post(f'/testcase/{tcid}/edit', data={
-            'tcid': 'TC1',
-            'tc_name': 'NewName',
-            'table_name': 'tbl2',
-            'test_type': 'CCD_Validation'
-        }, follow_redirects=True)
         assert resp.status_code == 200
-        with app.app_context():
-            updated = TestCaseModel.query.get(tcid)
-            assert updated.tc_name == 'NewName'
-            assert updated.table_name == 'tbl2'
-            src_path = proj_folder / 'input' / updated.src_data_file
-            tgt_path = proj_folder / 'input' / updated.tgt_data_file
-            assert src_path.exists() and tgt_path.exists()
-            assert src_path.read_text() == 'new src'
-            assert tgt_path.read_text() == 'new tgt'
-            assert not old_query.exists()
+    with app.app_context():
+        updated = TestCaseModel.query.get(tcid)
+        src_path = project_folder / 'input' / f'{updated.tcid}_src.sql'
+        tgt_path = project_folder / 'input' / f'{updated.tcid}_tgt.sql'
+        assert src_path.exists() and src_path.read_text() == 'new src'
+        assert tgt_path.exists() and tgt_path.read_text() == 'new tgt'
 
 
 def test_testcase_detail_route(tmp_path):
-    app = create_app()
+    app, project_folder, uid, pid = setup_project(tmp_path)
     with app.app_context():
-        db.drop_all()
-        db.create_all()
-        folder = tmp_path / "proj3"
-        folder.mkdir(parents=True)
-        (folder / "input").mkdir()
-        project = Project(name='Demo', folder_path=str(folder))
-        db.session.add(project)
-        db.session.commit()
-        user = User(username='u', email='u@example.com')
-        user.set_password('pwd')
-        project.users.append(user)
-        db.session.add(user)
-        tc = TestCaseModel(tcid='TC2', table_name='tbl', test_type='CCD_Validation', project_id=project.id)
+        tc = TestCaseModel(
+            tcid='TC2',
+            table_name='tbl',
+            test_type='CCD_Validation',
+            project_id=pid
+        )
         db.session.add(tc)
         db.session.commit()
-        uid = user.id
         tcid = tc.id
-
     with app.test_client() as client:
         login(client, uid)
         resp = client.get(f'/testcase/{tcid}')
         assert resp.status_code == 200
-        html = resp.data.decode()
-        assert 'Test Case Details' in html
-        assert 'TC2' in html
-
+        assert b'Test Case Details' in resp.data
+        assert b'TC2' in resp.data


### PR DESCRIPTION
## Summary
- create `TestCaseForm` with validation for metadata and source/target SQL
- save source and target SQL in `<tcid>_src.sql` and `<tcid>_tgt.sql`
- allow editing of stored SQL and added regression tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5c8644acc8323bb0c76cc38e56fc9